### PR TITLE
Reduce hero h1 font size on mobile to prevent word breaking

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,7 +34,7 @@ import sei from '../assets/sei.png';
         <span class="text-sm font-semibold text-blue-100">✓ Godkjent av Fiskeridirektoratet</span>
       </div>
 
-      <h1 class="text-5xl md:text-7xl font-bold mb-6 leading-tight break-words" id="hero-heading">
+      <h1 class="text-4xl md:text-7xl font-bold mb-6 leading-tight break-words" id="hero-heading">
         Spar timer hver uke på fangstrapportering
       </h1>
 


### PR DESCRIPTION
## Summary

Reduced the hero h1 font size on mobile viewports to prevent the long Norwegian word "fangstrapportering" from breaking across two lines.

## Change

**File**: `src/pages/index.astro` (line 37)

- **Before**: `text-5xl md:text-7xl`
- **After**: `text-4xl md:text-7xl`

## Reasoning

The word "fangstrapportering" (22 characters) is a long Norwegian compound word that was breaking onto two lines on mobile devices with the `text-5xl` (3rem / 48px) font size.

By reducing to `text-4xl` (2.25rem / 36px) on mobile, the word fits on a single line on most mobile devices (320px+), providing a cleaner, more professional appearance.

Desktop remains unchanged at `text-7xl` for maximum impact.

## Testing

- ✅ Tested on 320px, 375px, 390px, 414px viewports
- ✅ Word "fangstrapportering" stays on one line
- ✅ Desktop appearance unchanged (text-7xl)
- ✅ Build successful

## Related

Addresses typography refinement after mobile layout fixes in PR #2.