### PR TITLE
Add robots.txt for search engine crawl control

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://eksportfiske.no/sitemap.xml
+
+# Block build artifacts (if needed in future)
+Disallow: /_astro/


### PR DESCRIPTION
## Summary

- Created `public/robots.txt` for explicit search engine crawl control
- References sitemap.xml to help search engines discover the sitemap
- Blocks `/_astro/` build artifacts (future-proofing)

## Implementation

```txt
User-agent: *
Allow: /

Sitemap: https://eksportfiske.no/sitemap.xml

# Block build artifacts (if needed in future)
Disallow: /_astro/
```

## Benefits

- Explicit crawl permissions for search engines
- Sitemap reference helps search engine discovery
- Professional SEO infrastructure
- Easy to extend with additional rules if needed

## Test Plan

- [x] File created in `public/robots.txt`
- [x] Build includes robots.txt in dist/
- [x] Content matches specification in issue 20
- [ ] After deployment: Verify accessible at https://eksportfiske.no/robots.txt
- [ ] After deployment: Validate with Google Robots Testing Tool

## Files Changed

- `public/robots.txt` - New file

Closes #20