### PR TITLE
Remove 24-hour promise from contact section

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -652,9 +652,6 @@ import logo from '../assets/logo.png';
                 kontakt@eksportfiske.no
               </a>
             </li>
-            <li class="text-gray-400">
-              Vi svarer innen 24 timer
-            </li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
Fixes #8

## Changes

Removed "Vi svarer innen 24 timer" (We respond within 24 hours) from the contact section in the footer.

## Rationale

Making specific time-based promises that cannot be consistently guaranteed:
- Damages credibility and trust
- Creates unrealistic expectations
- Puts unnecessary pressure on support
- Better to under-promise and over-deliver

## Impact

- More honest communication with potential customers
- Reduced support pressure
- Maintains professional appearance without false assurances

## Verification

- Build successful
- Contact section still displays email address
- No other references to 24-hour promise found