### PR TITLE
Add force push safety protocol and fix visual regression workflow

### DIFF
--- a/.github/workflows/visual-regression-screenshots.yml
+++ b/.github/workflows/visual-regression-screenshots.yml
@@ -57,9 +57,18 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
+
+          # Get the original commit message to preserve it
+          ORIGINAL_MSG=$(git log -1 --pretty=%B)
+
+          # Stage screenshot changes
           git add screenshots/
-          git commit -m "Update visual regression screenshots"
-          git push
+
+          # Amend the existing commit instead of creating new one
+          git commit --amend --no-edit
+
+          # Force push with lease for safety
+          git push --force-with-lease
 
       - name: Confirm PR commit
         if: steps.check_changes.outputs.has_changes == 'true'


### PR DESCRIPTION
## Summary

This PR implements two critical improvements to our git workflow and visual regression system:

1. **Fix Visual Regression Workflow** - Updates the visual regression screenshot workflow to use commit amend instead of creating a second commit, enforcing our single commit policy
2. **Add Force Push Safety Protocol** - Documents comprehensive safety procedures for force push operations to prevent data loss

## Changes

### Visual Regression Workflow (.github/workflows/visual-regression-screenshots.yml)
- Changed from creating a new commit to amending the existing commit
- Added `--force-with-lease` for safe force pushing
- Preserves original commit message while adding screenshots
- Prevents workflow from violating single commit policy

### Project Instructions (.claude/CLAUDE.md)
- Added new "Force Push Safety Protocol" section
- Documents pre-force-push verification steps
- Provides clear procedures for when remote has changed
- Lists key rules and applies to all git operations (manual, automated, agents)

## Test Plan

- [ ] Review workflow YAML syntax is valid
- [ ] Review force push protocol documentation is clear and complete
- [ ] Verify the amended commit approach works in the visual regression workflow
- [ ] Confirm the safety protocol will prevent data loss scenarios