### PR TITLE
Improve visual regression workflow with safety checks and proper commit squashing

### DIFF
--- a/.github/workflows/visual-regression-screenshots.yml
+++ b/.github/workflows/visual-regression-screenshots.yml
@@ -58,22 +58,41 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
-          # Get the original commit message to preserve it
+          # Get the original commit message and author to preserve them
           ORIGINAL_MSG=$(git log -1 --pretty=%B)
+          ORIGINAL_AUTHOR=$(git log -1 --pretty=format:"%an <%ae>")
 
           # Stage screenshot changes
           git add screenshots/
 
-          # Amend the existing commit instead of creating new one
-          git commit --amend --no-edit
+          # Amend the existing commit, preserving original message and author
+          git commit --amend --no-edit --author="$ORIGINAL_AUTHOR"
 
-          # Force push with lease for safety
+          # Safety check: Verify remote hasn't changed before force push
+          git fetch origin ${{ github.head_ref }}
+          REMOTE_HASH=$(git rev-parse origin/${{ github.head_ref }})
+          LOCAL_BASE=$(git rev-parse HEAD~1)
+
+          if [ "$REMOTE_HASH" != "$LOCAL_BASE" ]; then
+            echo "❌ ERROR: Remote branch has new commits since we started!"
+            echo "Remote: $REMOTE_HASH"
+            echo "Expected: $LOCAL_BASE"
+            echo "Someone else has pushed changes. Aborting to prevent data loss."
+            exit 1
+          fi
+
+          # Force push with lease after verification
           git push --force-with-lease
 
       - name: Confirm PR commit
         if: steps.check_changes.outputs.has_changes == 'true'
         run: |
           echo '✅ Visual regression screenshots have been automatically generated and committed to this PR.'
+
+          # Add a comment to the PR
+          gh pr comment ${{ github.event.pull_request.number }} --body "📸 Visual regression screenshots automatically updated by GitHub Actions"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: No changes needed
         if: steps.check_changes.outputs.has_changes == 'false'


### PR DESCRIPTION
## Summary
Enhances the visual regression workflow to properly maintain single commit policy and add critical safety checks before force pushing.

## Changes

### 1. Proper Commit Squashing
- Preserves **original commit author** using `--author` flag
- Preserves original commit message with `--no-edit`
- Amends screenshots into existing commit (single commit maintained)

### 2. Force Push Safety Check
Implements the force push safety protocol from `.claude/CLAUDE.md`:
- Fetches remote state before force push
- Compares remote hash with expected base
- Aborts if remote has unexpected commits (prevents data loss)
- Only force pushes after verification

## Benefits

✅ **Single Commit Policy:** Screenshots are squashed into the original commit, not added as a second commit  
✅ **Author Preservation:** Original commit author is maintained (not overwritten by github-actions bot)  
✅ **Data Loss Prevention:** Safety check prevents overwriting commits if someone else pushed  
✅ **Idempotent:** Can run multiple times without creating duplicate commits

## How It Works

1. Workflow generates screenshots
2. Stages screenshot files
3. Amends them into the existing commit (preserving author and message)
4. Checks remote hasn't changed
5. Force pushes only after verification

## Test Plan
- ✅ Workflow syntax validated
- Will verify in practice on next PR that triggers visual regression

## Closes
Part of maintaining single commit policy across all workflows.