### PR TITLE
Add automatic rebase/retry to visual regression workflow

### DIFF
--- a/.github/workflows/visual-regression-screenshots.yml
+++ b/.github/workflows/visual-regression-screenshots.yml
@@ -182,14 +182,28 @@ jobs:
           LOCAL_BASE=$(git rev-parse HEAD~1)
 
           if [ "$REMOTE_HASH" != "$LOCAL_BASE" ]; then
-            echo "❌ ERROR: Remote branch has new commits since we started!"
+            echo "⚠️  Remote branch has new commits. Rebasing..."
             echo "Remote: $REMOTE_HASH"
             echo "Expected: $LOCAL_BASE"
-            echo "Someone else has pushed changes. Aborting to prevent data loss."
-            exit 1
+
+            # Reset to pre-amend state
+            git reset --soft HEAD~1
+
+            # Pull latest changes with rebase
+            git pull --rebase origin ${{ github.head_ref }}
+
+            # Get the new commit info after rebase
+            ORIGINAL_MSG=$(git log -1 --pretty=%B)
+            ORIGINAL_AUTHOR=$(git log -1 --pretty=format:"%an <%ae>")
+
+            # Re-stage and re-amend with screenshots
+            git add screenshots/
+            git commit --amend --no-edit --author="$ORIGINAL_AUTHOR"
+
+            echo "✅ Rebased successfully"
           fi
 
-          # Force push with lease after verification
+          # Force push with lease after verification/rebase
           git push --force-with-lease
 
       - name: Generate and post PR comment with visual diffs


### PR DESCRIPTION
## Summary

Enhances the visual regression workflow to automatically handle race conditions when the workflow detects that the remote branch has new commits.

## Problem

When the visual regression workflow runs and tries to amend + force push screenshots, it may encounter a race condition if new commits were pushed to the branch during workflow execution. Previously, the workflow would abort with an error:

```
❌ ERROR: Remote branch has new commits since we started!
Someone else has pushed changes. Aborting to prevent data loss.
```

This required manual intervention to rebase and re-run the workflow.

## Solution

The workflow now automatically handles this scenario by:

1. **Detecting the conflict**: Fetches remote and compares hashes
2. **Resetting gracefully**: Uses `git reset --soft HEAD~1` to undo the amend
3. **Rebasing**: Pulls latest changes with `git pull --rebase`
4. **Re-amending**: Applies screenshots to the new commit while preserving author/message
5. **Continuing**: Proceeds to force push with the rebased changes

## Benefits

- **Zero manual intervention**: Workflow recovers automatically from race conditions
- **Safe**: Still uses force push safety checks and `--force-with-lease`
- **Preserves history**: Maintains original commit authorship and messages
- **Robust**: Handles concurrent pushes gracefully

## Testing

This will be tested automatically when triggered on PRs. The workflow should now successfully complete even when race conditions occur.