### PR TITLE
Fix visual regression rebase to properly stash screenshots

### DIFF
--- a/.github/workflows/visual-regression-screenshots.yml
+++ b/.github/workflows/visual-regression-screenshots.yml
@@ -186,11 +186,18 @@ jobs:
             echo "Remote: $REMOTE_HASH"
             echo "Expected: $LOCAL_BASE"
 
-            # Reset to pre-amend state
+            # Reset to pre-amend state and unstage screenshots
             git reset --soft HEAD~1
+            git reset HEAD screenshots/
+
+            # Stash the screenshots temporarily
+            git stash push -u screenshots/
 
             # Pull latest changes with rebase
             git pull --rebase origin ${{ github.head_ref }}
+
+            # Restore the screenshots
+            git stash pop
 
             # Get the new commit info after rebase
             ORIGINAL_MSG=$(git log -1 --pretty=%B)


### PR DESCRIPTION
## Summary

Fixes the automatic rebase logic in the visual regression workflow to properly handle staged screenshot files.

## Problem

The workflow added in PR #50 attempted to rebase when detecting remote changes, but failed with:

```
error: cannot pull with rebase: Your index contains uncommitted changes.
error: Please commit or stash them.
```

This happened because after `git reset --soft HEAD~1`, the screenshots remained staged, preventing the rebase operation.

## Solution

Before rebasing:
1. Reset soft to undo the amend
2. **Unstage screenshots** with `git reset HEAD screenshots/`
3. **Stash screenshots** with `git stash push -u screenshots/`
4. Rebase with clean working tree
5. **Restore screenshots** with `git stash pop`
6. Re-amend with screenshots

## Changes

- Added `git reset HEAD screenshots/` to unstage after soft reset
- Added `git stash push -u screenshots/` before rebase
- Added `git stash pop` after rebase to restore screenshots

## Testing

This will be tested on PR #44 which is currently failing with the rebase error.