### PR TITLE
Fix visual regression to handle dimension mismatches

### DIFF
--- a/.github/workflows/visual-regression-screenshots.yml
+++ b/.github/workflows/visual-regression-screenshots.yml
@@ -94,6 +94,32 @@ jobs:
               continue
             fi
 
+            # Get dimensions of both images
+            BASE_DIMS=$(identify -format "%wx%h" "$BASE_IMG")
+            NEW_DIMS=$(identify -format "%wx%h" "$NEW_IMG")
+
+            # If dimensions differ, resize to match (extend canvas with white background)
+            if [ "$BASE_DIMS" != "$NEW_DIMS" ]; then
+              echo "Dimension mismatch for $FILENAME: base=$BASE_DIMS new=$NEW_DIMS"
+
+              # Get individual dimensions
+              BASE_W=$(echo $BASE_DIMS | cut -d'x' -f1)
+              BASE_H=$(echo $BASE_DIMS | cut -d'x' -f2)
+              NEW_W=$(echo $NEW_DIMS | cut -d'x' -f1)
+              NEW_H=$(echo $NEW_DIMS | cut -d'x' -f2)
+
+              # Calculate max dimensions
+              MAX_W=$((BASE_W > NEW_W ? BASE_W : NEW_W))
+              MAX_H=$((BASE_H > NEW_H ? BASE_H : NEW_H))
+
+              echo "Resizing both images to ${MAX_W}x${MAX_H}"
+
+              # Extend canvas to max dimensions (gravity NorthWest = extend right/bottom)
+              # -background white fills new areas with white
+              convert "$BASE_IMG" -background white -gravity NorthWest -extent "${MAX_W}x${MAX_H}" "$BASE_IMG"
+              convert "$NEW_IMG" -background white -gravity NorthWest -extent "${MAX_W}x${MAX_H}" "$NEW_IMG"
+            fi
+
             # Generate diff with odiff
             DIFF_IMG="screenshots/diffs/${FILENAME%.png}-diff.png"
 


### PR DESCRIPTION
## Summary

Fixes visual regression workflow to handle screenshots with different dimensions by extending canvas to match before odiff comparison.

## Problem

When page content changes affect page dimensions (e.g., adding a new section increases page height), odiff fails with exit code 22:

```
Error running odiff on desktop-full-page.png (exit code: 22)
Error running odiff on mobile-full-page.png (exit code: 22)
Error running odiff on tablet-full-page.png (exit code: 22)
```

This prevents visual diffs from being generated and the "Generate and post PR comment with visual diffs" step is skipped.

## Solution

Before running odiff, check if image dimensions differ and extend canvas to match:

1. **Detect dimension mismatch**: Use ImageMagick `identify` to get dimensions of both images
2. **Calculate max dimensions**: Find the larger width and height
3. **Extend canvas**: Use `convert -extent` with white background and NorthWest gravity
   - NorthWest gravity keeps image top-left aligned
   - Extension happens on right and/or bottom (where content was added)
   - White background fills new areas

## Implementation Details

```bash
# Get dimensions
BASE_DIMS=$(identify -format "%wx%h" "$BASE_IMG")
NEW_DIMS=$(identify -format "%wx%h" "$NEW_IMG")

# If different, extend both to max dimensions
if [ "$BASE_DIMS" != "$NEW_DIMS" ]; then
  MAX_W=$((BASE_W > NEW_W ? BASE_W : NEW_W))
  MAX_H=$((BASE_H > NEW_H ? BASE_H : NEW_H))
  
  convert "$BASE_IMG" -background white -gravity NorthWest -extent "${MAX_W}x${MAX_H}" "$BASE_IMG"
  convert "$NEW_IMG" -background white -gravity NorthWest -extent "${MAX_W}x${MAX_H}" "$NEW_IMG"
fi
```

## Benefits

- Visual diffs work even when page dimensions change
- White background clearly shows where content was added
- Supports both height changes (vertical content) and width changes (horizontal content)
- odiff comparison succeeds and generates proper diff masks

## Testing

This will be tested on PR #44 which currently fails with dimension mismatch errors.