### PR TITLE
Fix canvas extension to use mogrify for in-place modification

### DIFF
--- a/.github/workflows/visual-regression-screenshots.yml
+++ b/.github/workflows/visual-regression-screenshots.yml
@@ -116,8 +116,9 @@ jobs:
 
               # Extend canvas to max dimensions (gravity NorthWest = extend right/bottom)
               # -background white fills new areas with white
-              convert "$BASE_IMG" -background white -gravity NorthWest -extent "${MAX_W}x${MAX_H}" "$BASE_IMG"
-              convert "$NEW_IMG" -background white -gravity NorthWest -extent "${MAX_W}x${MAX_H}" "$NEW_IMG"
+              # Use mogrify to modify files in-place
+              mogrify -background white -gravity NorthWest -extent "${MAX_W}x${MAX_H}" "$BASE_IMG"
+              mogrify -background white -gravity NorthWest -extent "${MAX_W}x${MAX_H}" "$NEW_IMG"
             fi
 
             # Generate diff with odiff


### PR DESCRIPTION
## Summary

Fixes the canvas extension logic to properly modify images in-place using `mogrify` instead of `convert`.

## Problem

The dimension mismatch fix in PR #52 uses `convert` to extend canvas:

```bash
convert "$BASE_IMG" -background white -gravity NorthWest -extent "${MAX_W}x${MAX_H}" "$BASE_IMG"
```

However, `convert` may not properly modify files in-place, causing odiff to still see dimension mismatches (exit code 22).

## Solution

Use `mogrify` which is designed for in-place image modification:

```bash
mogrify -background white -gravity NorthWest -extent "${MAX_W}x${MAX_H}" "$BASE_IMG"
```

## Benefits

- Properly modifies images in-place
- odiff will receive images with matching dimensions
- Visual diffs will be generated successfully

## Testing

Will test on PR #44 after merging.