### PR TITLE
Add debug output for canvas extension

### DIFF
--- a/.github/workflows/visual-regression-screenshots.yml
+++ b/.github/workflows/visual-regression-screenshots.yml
@@ -119,6 +119,11 @@ jobs:
               # Use mogrify to modify files in-place
               mogrify -background white -gravity NorthWest -extent "${MAX_W}x${MAX_H}" "$BASE_IMG"
               mogrify -background white -gravity NorthWest -extent "${MAX_W}x${MAX_H}" "$NEW_IMG"
+
+              # Verify dimensions after resize
+              BASE_DIMS_AFTER=$(identify -format "%wx%h" "$BASE_IMG")
+              NEW_DIMS_AFTER=$(identify -format "%wx%h" "$NEW_IMG")
+              echo "After resize: base=$BASE_DIMS_AFTER new=$NEW_DIMS_AFTER"
             fi
 
             # Generate diff with odiff


### PR DESCRIPTION
## Summary

Adds debug output to verify image dimensions after mogrify operations.

## Purpose

Currently experiencing exit code 22 (dimension mismatch) from odiff even after running mogrify to extend canvas. This PR adds debug logging to verify:
1. Dimensions before resize
2. Dimensions after resize
3. Whether mogrify is successfully modifying the files

## Output

Will show:
```
Dimension mismatch for desktop-full-page.png: base=1280x5699 new=1280x6703
Resizing both images to 1280x6703
After resize: base=1280x6703 new=1280x6703  <-- This will help us verify
```

## Next Steps

Based on the debug output, we'll know if:
- mogrify is working correctly → investigate why odiff still fails
- mogrify is NOT working → need different approach (temp files, different command, etc.)