### PR TITLE
Fix odiff exit code check: should be 22 for pixel differences, not 21

### DIFF
--- a/.github/workflows/visual-regression-screenshots.yml
+++ b/.github/workflows/visual-regression-screenshots.yml
@@ -130,13 +130,13 @@ jobs:
             DIFF_IMG="screenshots/diffs/${FILENAME%.png}-diff.png"
 
             # Run odiff with threshold of 0.1 (10% tolerance)
-            # Exit code: 0 = identical, 21 = different, other = error
+            # Exit code: 0 = identical, 22 = pixel differences, 21 = layout difference (with --fail-on-layout)
             if odiff "$BASE_IMG" "$NEW_IMG" "$DIFF_IMG" --threshold 0.1 > /dev/null 2>&1; then
               echo "No visual changes in $FILENAME"
               rm -f "$DIFF_IMG"
             else
               EXIT_CODE=$?
-              if [ $EXIT_CODE -eq 21 ]; then
+              if [ $EXIT_CODE -eq 22 ]; then
                 echo "Visual changes detected in $FILENAME"
                 HAS_DIFFS=true
 


### PR DESCRIPTION
## Problem

The visual regression workflow added in PR #49 has been failing to detect visual changes and generate PR comments with diff images. All screenshot comparisons were being logged as errors with exit code 22.

**Root cause:** The workflow was checking for exit code 21 to detect visual differences, but odiff actually returns exit code 22 for pixel differences.

## Evidence

From PR #44's workflow run logs:
```
Error running odiff on desktop-full-page.png (exit code: 22)
Error running odiff on mobile-full-page.png (exit code: 22)  
Error running odiff on tablet-full-page.png (exit code: 22)
```

This caused HAS_DIFFS=false, which skipped the PR comment generation step entirely.

## odiff Exit Codes (from source)

According to odiff's usage documentation:
- **Exit code 0** - Images match
- **Exit code 21** - Layout difference (only when --fail-on-layout flag is used)
- **Exit code 22** - Pixel differences found

## Fix

Changed the exit code check from 21 to 22:

**Before:**
```bash
if [ EXIT_CODE -eq 21 ]; then
  echo "Visual changes detected in FILENAME"
  HAS_DIFFS=true
```

**After:**
```bash
if [ EXIT_CODE -eq 22 ]; then
  echo "Visual changes detected in FILENAME"
  HAS_DIFFS=true
```

Also updated the comment to document the correct exit codes.

## Impact

After this fix, the visual regression workflow will:
- Properly detect when screenshots have visual changes
- Generate diff images with highlighted changes
- Post PR comments with side-by-side comparisons
- Provide automatic visual regression feedback on all PRs

## Testing

This PR will test itself - when visual changes are detected on a PR, the workflow should now properly generate and post diff images in a PR comment.

## Related

- PR #49 - Added odiff integration (merged)
- PR #44 - First PR affected by this bug
- PRs #50, #51, #52 - Related workflow improvements