### PR TITLE
Fix visual diff cropping to only show changed regions

### DIFF
--- a/.github/workflows/visual-regression-screenshots.yml
+++ b/.github/workflows/visual-regression-screenshots.yml
@@ -128,6 +128,7 @@ jobs:
 
             # Generate diff with odiff
             DIFF_IMG="screenshots/diffs/${FILENAME%.png}-diff.png"
+            DIFF_MASK="screenshots/diffs/${FILENAME%.png}-diff-mask.png"
 
             # Run odiff with threshold of 0.1 (10% tolerance)
             # Exit code: 0 = identical, 22 = pixel differences, 21 = layout difference (with --fail-on-layout)
@@ -140,9 +141,15 @@ jobs:
                 echo "Visual changes detected in $FILENAME"
                 HAS_DIFFS=true
 
-                # Get bounding box of changes using ImageMagick
+                # Generate diff mask (only changed pixels over transparent background)
+                odiff "$BASE_IMG" "$NEW_IMG" "$DIFF_MASK" --diff-mask --threshold 0.1 > /dev/null 2>&1
+
+                # Get bounding box of changes using ImageMagick on the transparent mask
                 # This finds the smallest rectangle containing all non-transparent pixels
-                BBOX=$(convert "$DIFF_IMG" -trim +repage -format "%wx%h+%X+%Y" info:)
+                BBOX=$(convert "$DIFF_MASK" -trim +repage -format "%wx%h+%X+%Y" info:)
+
+                # Clean up mask after getting bounding box
+                rm -f "$DIFF_MASK"
 
                 # Add 10px padding to bounding box
                 WIDTH=$(echo $BBOX | cut -d'x' -f1)


### PR DESCRIPTION
## Problem

The visual regression diff images are showing the entire screenshot from the top instead of cropping to just the changed area. 

**Current behavior:** Diff crops start at position 0,0 (top-left) and include ~1000px+ of unchanged content
- Example: `1300x6461+0+0` - starts at top-left corner, includes entire height

**Expected behavior:** Diff crops should show only the changed region with 10px padding

## Root Cause

The workflow uses ImageMagick's `-trim` on the regular odiff output to find the bounding box:
```bash
BBOX=$(convert "$DIFF_IMG" -trim +repage -format "%wx%h+%X+%Y" info:)
```

However, odiff's default output is the **full image** with changed pixels highlighted (not a sparse mask). This means `-trim` finds non-transparent pixels starting at 0,0.

## Solution

Use odiff's `--diff-mask` flag to generate a transparent mask with **only changed pixels**. Then ImageMagick's trim can find the actual bounding box of changes:

```bash
# Generate diff mask (only changed pixels over transparent background)
odiff "$BASE_IMG" "$NEW_IMG" "$DIFF_MASK" --diff-mask --threshold 0.1

# Get bounding box from the mask
BBOX=$(convert "$DIFF_MASK" -trim +repage -format "%wx%h+%X+%Y" info:)
```

## Changes

1. Generate a temporary diff mask using `--diff-mask`
2. Use the mask to find the true bounding box of changes
3. Clean up the mask after extracting bounding box
4. Apply the bounding box to crop all three images (base, new, diff)

## Impact

- Diff images will be much smaller and focused
- Reviewers can immediately see what changed without scrolling
- Reduced image size = faster loading in PR comments
- Clearer visual regression feedback

## Testing

This will be tested automatically on PR #44 which has visual changes in the tourist benefits section (should crop to that section only, not show the entire page from top).