### PR TITLE
Fix diff mask generation exit code handling

### DIFF
--- a/.github/workflows/visual-regression-screenshots.yml
+++ b/.github/workflows/visual-regression-screenshots.yml
@@ -142,7 +142,8 @@ jobs:
                 HAS_DIFFS=true
 
                 # Generate diff mask (only changed pixels over transparent background)
-                odiff "$BASE_IMG" "$NEW_IMG" "$DIFF_MASK" --diff-mask --threshold 0.1 > /dev/null 2>&1
+                # Note: odiff will return exit code 22 (differences found), which we ignore
+                odiff "$BASE_IMG" "$NEW_IMG" "$DIFF_MASK" --diff-mask --threshold 0.1 > /dev/null 2>&1 || true
 
                 # Get bounding box of changes using ImageMagick on the transparent mask
                 # This finds the smallest rectangle containing all non-transparent pixels


### PR DESCRIPTION
## Problem

Visual regression workflow fails immediately after detecting changes with error:
```
Visual changes detected in desktop-full-page.png
##[error]Process completed with exit code 22.
```

## Root Cause

In PR #56, we added code to generate a diff mask using odiff:
```bash
odiff "$BASE_IMG" "$NEW_IMG" "$DIFF_MASK" --diff-mask --threshold 0.1 > /dev/null 2>&1
```

However, odiff returns **exit code 22** when pixel differences are found. Since the workflow script runs with `bash -e` (exit on error), the script exits immediately after this command.

## Fix

Added `|| true` to ignore the exit code and continue processing:
```bash
odiff "$BASE_IMG" "$NEW_IMG" "$DIFF_MASK" --diff-mask --threshold 0.1 > /dev/null 2>&1 || true
```

This allows the workflow to:
1. Generate the diff mask
2. Extract the bounding box from the mask
3. Crop the images to the changed region
4. Complete successfully

## Testing

Will be tested automatically on PR #44 after merge.