### PR TITLE
Ignore antialiasing in diff mask for better crop positioning

### DIFF
--- a/.github/workflows/visual-regression-screenshots.yml
+++ b/.github/workflows/visual-regression-screenshots.yml
@@ -143,7 +143,8 @@ jobs:
 
                 # Generate diff mask (only changed pixels over transparent background)
                 # Note: odiff will return exit code 22 (differences found), which we ignore
-                odiff "$BASE_IMG" "$NEW_IMG" "$DIFF_MASK" --diff-mask --threshold 0.1 > /dev/null 2>&1 || true
+                # Using --antialiasing to ignore antialiased pixels that cause false positives
+                odiff "$BASE_IMG" "$NEW_IMG" "$DIFF_MASK" --diff-mask --threshold 0.1 --antialiasing > /dev/null 2>&1 || true
 
                 # Get bounding box of changes using ImageMagick on the transparent mask
                 # This finds the smallest rectangle containing all non-transparent pixels


### PR DESCRIPTION
## Problem

The visual diff crops are starting at position 0,0 even though the actual meaningful changes (tourist benefits section) are further down the page.

**Current behavior:**
```
Cropped changes in desktop-full-page.png to 1300x3268+0+0
Cropped changes in mobile-full-page.png to 439x5730+0+0
Cropped changes in tablet-full-page.png to 788x3404+0+0
```

All crops start at `+0+0` (top-left corner), including ~1000px+ of unchanged header content.

## Root Cause

When generating the diff mask, odiff is detecting minor pixel differences at the top of the page from:
- Antialiasing variations
- Font rendering differences  
- Subpixel rendering inconsistencies

These tiny differences cause the bounding box trim operation to include pixels from the very top of the image.

## Solution

Added `--antialiasing` flag to the diff mask generation:

```bash
odiff "$BASE_IMG" "$NEW_IMG" "$DIFF_MASK" --diff-mask --threshold 0.1 --antialiasing
```

This tells odiff to ignore antialiased pixels, which should eliminate false positives from rendering variations and allow the bounding box to correctly identify the actual content changes (tourist benefits section).

## Expected Result

Crops should now start at the Y position where the tourist benefits section begins (e.g., `+0+3000` or similar), not `+0+0`.

## Testing

Will be tested on PR #44 which adds the tourist benefits section.