### PR TITLE
Remove redundant screenshot update PR comment

### DIFF
--- a/.github/workflows/visual-regression-screenshots.yml
+++ b/.github/workflows/visual-regression-screenshots.yml
@@ -305,11 +305,6 @@ jobs:
         run: |
           echo '✅ Visual regression screenshots have been automatically generated and committed to this PR.'
 
-          # Add a comment to the PR
-          gh pr comment ${{ github.event.pull_request.number }} --body "📸 Visual regression screenshots automatically updated by GitHub Actions"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: No changes needed
         if: steps.check_changes.outputs.has_changes == 'false'
         run: |


### PR DESCRIPTION
## Changes

Removed the automatic PR comment that says "📸 Visual regression screenshots automatically updated by GitHub Actions".

## Reason

This comment is redundant because:
1. The workflow already posts a **detailed visual diff comment** when changes are detected (showing side-by-side comparisons)
2. The simple "screenshots updated" message adds no value
3. It creates noise in the PR conversation

## Result

PRs will now only receive:
- ✅ The detailed visual regression diff comment (when there are visual changes)
- 🔇 No redundant "screenshots updated" message

This keeps PR conversations cleaner and more focused on the actual visual changes.