### PR TITLE
Fix bounding box detection using alpha channel extraction

### DIFF
--- a/.github/workflows/visual-regression-screenshots.yml
+++ b/.github/workflows/visual-regression-screenshots.yml
@@ -147,8 +147,8 @@ jobs:
                 odiff "$BASE_IMG" "$NEW_IMG" "$DIFF_MASK" --diff-mask --threshold 0.1 --antialiasing > /dev/null 2>&1 || true
 
                 # Get bounding box of changes using ImageMagick on the transparent mask
-                # This finds the smallest rectangle containing all non-transparent pixels
-                BBOX=$(convert "$DIFF_MASK" -trim +repage -format "%wx%h+%X+%Y" info:)
+                # Extract alpha channel and trim to find the smallest rectangle containing changes
+                BBOX=$(convert "$DIFF_MASK" -alpha extract -trim -format "%wx%h+%X+%Y" info:)
 
                 # Clean up mask after getting bounding box
                 rm -f "$DIFF_MASK"


### PR DESCRIPTION
## Problem

Visual diff crops are still starting at position `+0+0` even though the actual meaningful changes are further down the page.

**Current behavior:**
```
Cropped changes in desktop-full-page.png to 1300x3464+0+0
Cropped changes in mobile-full-page.png to 439x9117+0+0
Cropped changes in tablet-full-page.png to 788x3612+0+0
```

## Root Cause

The current command uses `convert -trim` which looks for non-transparent pixels, but odiff's diff mask may have semi-transparent or colored pixels at the top that aren't actual significant changes.

**Current (incorrect):**
```bash
BBOX=$(convert "$DIFF_MASK" -trim +repage -format "%wx%h+%X+%Y" info:)
```

## Solution

Use `-alpha extract` to extract the alpha channel as a grayscale image before trimming. This provides more accurate detection of where actual changes are located.

**New (correct):**
```bash
BBOX=$(convert "$DIFF_MASK" -alpha extract -trim -format "%wx%h+%X+%Y" info:)
```

This approach:
1. Extracts the alpha channel (transparency) as a grayscale image
2. Trims the grayscale to find the true bounding box of non-transparent areas
3. Returns accurate offset coordinates

## Expected Result

Crops should now correctly start at the Y position where actual changes begin (e.g., `+0+2543` for tourist benefits section), not `+0+0`.

## Testing

Will be tested on PR #44.