### PR TITLE
Don't commit diff images to repository

### DIFF
--- a/.github/workflows/visual-regression-screenshots.yml
+++ b/.github/workflows/visual-regression-screenshots.yml
@@ -237,8 +237,9 @@ jobs:
       - name: Check for screenshot changes
         id: check_changes
         run: |
-          # Check for both modified AND untracked files in screenshots/
-          if [ -z "$(git status --porcelain screenshots/)" ]; then
+          # Check for both modified AND untracked files in screenshots/ (excluding diffs/)
+          # Diffs are only for PR comments, not committed
+          if [ -z "$(git status --porcelain screenshots/*.png)" ]; then
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else
             echo "has_changes=true" >> $GITHUB_OUTPUT
@@ -254,8 +255,8 @@ jobs:
           ORIGINAL_MSG=$(git log -1 --pretty=%B)
           ORIGINAL_AUTHOR=$(git log -1 --pretty=format:"%an <%ae>")
 
-          # Stage screenshot changes (including diffs if present)
-          git add screenshots/
+          # Stage only base screenshot changes, NOT the diffs (diffs are only for PR comments)
+          git add screenshots/*.png
 
           # Amend the existing commit, preserving original message and author
           git commit --amend --no-edit --author="$ORIGINAL_AUTHOR"


### PR DESCRIPTION
## Problem

Currently the workflow commits the entire `screenshots/` directory, which includes:
- `screenshots/*.png` - Base reference screenshots ✅
- `screenshots/diffs/` - Diff images and cropped comparisons ❌

The diff images should only be shown in PR comments, not stored in the repository.

## Changes

1. **Only commit base screenshots:**
   ```bash
   git add screenshots/*.png  # Only *.png in root, not diffs/
   ```

2. **Update change detection:**
   ```bash
   git status --porcelain screenshots/*.png  # Exclude diffs/
   ```

## Result

- ✅ Base screenshots committed (reference for future comparisons)
- ❌ Diff images NOT committed (temporary artifacts for PR comments only)
- 🧹 Cleaner repository without temporary comparison files

## Impact

The diff images are still:
- Generated during workflow execution
- Displayed in PR comments via GitHub's raw content URLs
- Available during the workflow run

They're just not persisted in the git history.