### PR TITLE
Explicitly remove diffs directory before committing

### DIFF
--- a/.github/workflows/visual-regression-screenshots.yml
+++ b/.github/workflows/visual-regression-screenshots.yml
@@ -255,7 +255,12 @@ jobs:
           ORIGINAL_MSG=$(git log -1 --pretty=%B)
           ORIGINAL_AUTHOR=$(git log -1 --pretty=format:"%an <%ae>")
 
-          # Stage only base screenshot changes, NOT the diffs (diffs are only for PR comments)
+          # Remove diffs directory from git tracking if it exists
+          # Diffs are only for PR comments, never committed
+          git rm -r --cached screenshots/diffs/ 2>/dev/null || true
+          rm -rf screenshots/diffs/
+
+          # Stage only base screenshot changes
           git add screenshots/*.png
 
           # Amend the existing commit, preserving original message and author


### PR DESCRIPTION
## Problem

The diffs directory (`screenshots/diffs/`) is still being committed even though we only do `git add screenshots/*.png`.

**Root cause:** `git commit --amend` includes all currently tracked files, not just staged ones. Since diffs were committed in previous test runs, they remain tracked and get included in the amend.

## Fix

Before committing, explicitly remove the diffs directory:

```bash
# Remove from git tracking
git rm -r --cached screenshots/diffs/ 2>/dev/null || true

# Delete from filesystem  
rm -rf screenshots/diffs/

# Now only stage base screenshots
git add screenshots/*.png
```

## Result

- ✅ Base screenshots (`screenshots/*.png`) are committed
- ❌ Diffs directory (`screenshots/diffs/`) is NOT committed
- ✅ Diffs still shown in PR comments (via raw URLs during workflow run)
- 🧹 Repository stays clean

## Note

The diffs are generated during the workflow and used for the PR comment. They exist temporarily in the workflow's working directory and are accessible via GitHub's raw content URLs while the workflow runs, but are never persisted in git history.