### PR TITLE
Add screenshots/diffs/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ playwright/.cache/
 
 # but DO commit screenshots for visual regression
 !screenshots/*.png
+
+# NEVER commit diff images (only for PR comments)
+screenshots/diffs/


### PR DESCRIPTION
## Problem

The `screenshots/diffs/` directory is still being committed despite our attempts to exclude it, because once files are tracked by Git, they remain tracked even after being removed from staging.

## Root Cause

Git tracks files that were previously committed. Even though we:
1. Only run `git add screenshots/*.png`
2. Run `git rm -r --cached screenshots/diffs/`  
3. Run `rm -rf screenshots/diffs/`

When using `git commit --amend`, Git includes all tracked files from the previous commit unless explicitly removed.

## Solution

Add `screenshots/diffs/` to `.gitignore`:

```gitignore
# NEVER commit diff images (only for PR comments)
screenshots/diffs/
```

This ensures Git will NEVER track these files, making it impossible for them to be committed.

## Additional Cleanup Needed

After merging this, we'll need to remove the existing tracked diff files from PR #44:
```bash
git rm -r screenshots/diffs/
git commit -m 'Remove tracked diff files'
```

## Impact

- ✅ `.gitignore` prevents any future tracking of diffs
- ✅ Works with `git commit --amend`
- ✅ Diffs still shown in PR comments (temporary files during workflow)
- 🧹 Clean repository without comparison artifacts