### PR TITLE
Fix ImageMagick command in visual regression workflow

### DIFF
--- a/.github/workflows/visual-regression-screenshots.yml
+++ b/.github/workflows/visual-regression-screenshots.yml
@@ -221,7 +221,7 @@ jobs:
                 convert "$NEW_IMG" -crop "$CROP_SPEC" +repage "$NEW_CROP"
 
                 # Combine images horizontally: Original | Diff | New
-                magick "$BASE_CROP" "$DIFF_CROP" "$NEW_CROP" +append "$COMBINED"
+                convert "$BASE_CROP" "$DIFF_CROP" "$NEW_CROP" +append "$COMBINED"
 
                 echo "Created combined image: $COMBINED (${CROP_SPEC})"
               else


### PR DESCRIPTION
## Issue

The visual regression workflow was failing with:
```
magick: command not found
```

## Root Cause

Used `magick` command (ImageMagick 7) but the workflow installs ImageMagick 6 via apt-get, which only provides `convert` command.

## Fix

Changed line 224 from:
```bash
magick "$BASE_CROP" "$DIFF_CROP" "$NEW_CROP" +append "$COMBINED"
```

To:
```bash
convert "$BASE_CROP" "$DIFF_CROP" "$NEW_CROP" +append "$COMBINED"
```

This makes it consistent with all other ImageMagick operations in the workflow which use `convert`.