### PR TITLE
[Option 1] Soften hero banner - Lighter gradient with lower opacity

### DIFF
--- a/.github/workflows/visual-regression-screenshots.yml
+++ b/.github/workflows/visual-regression-screenshots.yml
@@ -62,3 +62,4 @@ jobs:
           mode: compare
           ci-branch-name: '_ci'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          imgbb-api-key: ${{ secrets.IMGBB_API_KEY }}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,7 +29,7 @@ import logo from '../assets/logo.png';
     <!-- Background Image -->
     <div class="absolute inset-0" aria-hidden="true">
       <Image src={heroBg} alt="" class="w-full h-full object-cover" widths={[640, 1024, 1280, 1920]} sizes="100vw" />
-      <div class="absolute inset-0 bg-gradient-to-br from-primary/90 to-primary-active/90"></div>
+      <div class="absolute inset-0 bg-gradient-to-br from-blue-500/70 to-blue-600/80"></div>
     </div>
 
     <div class="w-full mx-auto text-center max-w-5xl relative z-10 px-4">


### PR DESCRIPTION
## Option 1: Lighter Gradient with Lower Opacity

Part of Issue #92 - comparing 5 different approaches to soften the hero banner blue background.

### Changes
- Changed from  to 
- Uses lighter blue shades (500/600 instead of 600/700)
- Reduced opacity (70%/80% instead of 90%/90%)

### Visual Effect
- Significantly softer appearance
- More of the background image shows through
- Maintains blue brand color but less intense
- More welcoming, approachable feel

### Comparison
This is **Option 1 of 5** - please review all options before deciding:
- **Option 1** (this PR): Lighter gradient with lower opacity
- Option 2: Multi-color gradient
- Option 3: Softer blue with sky blend
- Option 4: Radial gradient spotlight
- Option 5: Pattern overlay

Related to #92