### PR TITLE
[Option 2] Soften hero banner - Multi-color gradient with depth

### DIFF
--- a/.github/workflows/visual-regression-screenshots.yml
+++ b/.github/workflows/visual-regression-screenshots.yml
@@ -62,3 +62,4 @@ jobs:
           mode: compare
           ci-branch-name: '_ci'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          imgbb-api-key: ${{ secrets.IMGBB_API_KEY }}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,7 +29,7 @@ import logo from '../assets/logo.png';
     <!-- Background Image -->
     <div class="absolute inset-0" aria-hidden="true">
       <Image src={heroBg} alt="" class="w-full h-full object-cover" widths={[640, 1024, 1280, 1920]} sizes="100vw" />
-      <div class="absolute inset-0 bg-gradient-to-br from-primary/90 to-primary-active/90"></div>
+      <div class="absolute inset-0 bg-gradient-to-br from-blue-400/75 via-blue-500/80 to-blue-600/85"></div>
     </div>
 
     <div class="w-full mx-auto text-center max-w-5xl relative z-10 px-4">


### PR DESCRIPTION
## Option 2: Multi-Color Gradient

Part of Issue #92 - comparing 5 different approaches to soften the hero banner blue background.

### Changes
- Three-stop gradient: from-blue-400/75 via-blue-500/80 to-blue-600/85
- Gradual opacity increase creates depth

### Visual Effect  
- Softer, more nuanced color transition
- Added visual dimension with via color
- Still professional while less intense

### Comparison
This is **Option 2 of 5**
Related to #92