### PR TITLE
[Option 3] Soften hero banner - Softer blue with sky blend

### DIFF
--- a/.github/workflows/visual-regression-screenshots.yml
+++ b/.github/workflows/visual-regression-screenshots.yml
@@ -62,3 +62,4 @@ jobs:
           mode: compare
           ci-branch-name: '_ci'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          imgbb-api-key: ${{ secrets.IMGBB_API_KEY }}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,7 +29,7 @@ import logo from '../assets/logo.png';
     <!-- Background Image -->
     <div class="absolute inset-0" aria-hidden="true">
       <Image src={heroBg} alt="" class="w-full h-full object-cover" widths={[640, 1024, 1280, 1920]} sizes="100vw" />
-      <div class="absolute inset-0 bg-gradient-to-br from-primary/90 to-primary-active/90"></div>
+      <div class="absolute inset-0 bg-gradient-to-br from-blue-400/70 to-sky-500/75"></div>
     </div>
 
     <div class="w-full mx-auto text-center max-w-5xl relative z-10 px-4">


### PR DESCRIPTION
## Option 3: Softer Blue with Sky Tone

Part of Issue #92

### Changes
- from-blue-400/70 to-sky-500/75
- Blends with lighter sky tones

### Visual Effect
- Airier, gentler appearance
- Maritime association maintained

Related to #92