### PR TITLE
Fix: add imgbb-api-key to capture step

### DIFF
--- a/.github/workflows/visual-regression-screenshots.yml
+++ b/.github/workflows/visual-regression-screenshots.yml
@@ -30,6 +30,7 @@ jobs:
           mode: capture
           playwright-command: 'npm run build && npx playwright test'
           artifact-name: screenshots-${{ matrix.branch }}
+          imgbb-api-key: ${{ secrets.IMGBB_API_KEY }}
 
       - name: Upload screenshots
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fixes workflow error where imgbb-api-key was missing from the capture step.

The visual-regression-action@v1 requires the imgbb-api-key in both capture and compare modes.