### PR TITLE
Fix: add imgbb-api-key to compare step

### DIFF
--- a/.github/workflows/visual-regression-screenshots.yml
+++ b/.github/workflows/visual-regression-screenshots.yml
@@ -63,3 +63,4 @@ jobs:
           mode: compare
           ci-branch-name: '_ci'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          imgbb-api-key: ${{ secrets.IMGBB_API_KEY }}


### PR DESCRIPTION
The compare step in the visual regression workflow also needs the imgbb-api-key parameter, not just the capture step.