### PR TITLE
Update export quota year from 2025 to 2026

### DIFF
--- a/src/pages/registrering.astro
+++ b/src/pages/registrering.astro
@@ -241,7 +241,7 @@ import Layout from '../layouts/Layout.astro';
                       <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
                     </svg>
                   </span>
-                  <span class="text-gray-700"><strong class="text-green-700">18 kg (2025)</strong></span>
+                  <span class="text-gray-700"><strong class="text-green-700">18 kg (2026)</strong></span>
                 </div>
               </td>
             </tr>


### PR DESCRIPTION
## Summary
Updates the export quota year reference from 2025 to 2026 in the comparison table.

## Changes
- `18 kg (2025)` → `18 kg (2026)`

## Test plan
- [ ] Verify the comparison table shows "18 kg (2026)"