### PR TITLE
Use Norwegian success message for contact form

### DIFF
--- a/src/pages/kontakt.astro
+++ b/src/pages/kontakt.astro
@@ -312,7 +312,6 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
       // Show success message
       if (formSuccess && formSuccessMessage) {
         formSuccessMessage.textContent =
-          result.message ||
           'Din melding er sendt! Vi kontakter deg snart.';
         formSuccess.classList.remove('hidden');
       }


### PR DESCRIPTION
## Summary
Always display Norwegian success message instead of using English response from backend.

## Changes
- Hardcode Norwegian message: "Din melding er sendt! Vi kontakter deg snart."
- Previously used `result.message` from backend which returned English text

## Test plan
- [ ] Submit contact form
- [ ] Verify success message appears in Norwegian