### PR TITLE
Fix #121: Add missing periods to sentences

### DIFF
--- a/src/pages/registrering.astro
+++ b/src/pages/registrering.astro
@@ -21,7 +21,7 @@ import Layout from '../layouts/Layout.astro';
             </div>
             <div>
               <h2 id="quiz-header-title" class="text-3xl font-bold text-white">Har du en turistfiskebedrift uten å vite det?</h2>
-              <p id="quiz-header-subtitle" class="text-blue-100 text-lg mt-1">Sjekk om du må registrere turistfiskebedrift</p>
+              <p id="quiz-header-subtitle" class="text-blue-100 text-lg mt-1">Sjekk om du må registrere turistfiskebedrift.</p>
             </div>
           </div>
         </div>
@@ -151,7 +151,7 @@ import Layout from '../layouts/Layout.astro';
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
           </svg>`;
           quizHeaderTitle.textContent = 'Har du en turistfiskebedrift uten å vite det?';
-          quizHeaderSubtitle.textContent = 'Sjekk om du må registrere turistfiskebedrift';
+          quizHeaderSubtitle.textContent = 'Sjekk om du må registrere turistfiskebedrift.';
           quizHeaderSubtitle.className = 'text-blue-100 text-lg mt-1';
         }
       }
@@ -192,7 +192,7 @@ import Layout from '../layouts/Layout.astro';
       <div class="text-center mb-10">
         <h2 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">Konsekvenser av å ikke registrere som turistfiskebedrift</h2>
         <p class="text-lg text-gray-600 max-w-2xl mx-auto">
-          Manglende registrering og rapportering kan ha alvorlige konsekvenser – både for deg og gjestene dine
+          Manglende registrering og rapportering kan ha alvorlige konsekvenser – både for deg og gjestene dine.
         </p>
       </div>
 


### PR DESCRIPTION
## Summary
Adds missing periods to sentence endings on the registration information page for proper punctuation.

## Changes
- Added period to "Sjekk om du må registrere turistfiskebedrift" (line 24)
- Added period in JavaScript for same text (line 154)
- Added period to "både for deg og gjestene dine" (line 195)

## Test Plan
- [x] Verify all three locations now have proper punctuation
- [x] Visual regression check will run automatically

Fixes #121