### PR TITLE
Fix #124: Change main CTA from 'Kom i gang nå' to 'Bestill nå'

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -76,7 +76,7 @@ import logo from '../assets/logo.png';
           class="relative overflow-hidden bg-white text-blue-900 hover:bg-blue-50 font-semibold text-base sm:text-lg px-6 sm:px-8 py-3 sm:py-4 rounded-lg transition-all transform hover:scale-105 shadow-xl text-center"
           href="/registrer"
         >
-          <span class="relative z-10">Kom i gang nå</span>
+          <span class="relative z-10">Bestill nå</span>
         </a>
         <a
           class="bg-transparent hover:bg-white/10 text-white font-semibold text-base sm:text-lg px-6 sm:px-8 py-3 sm:py-4 rounded-lg border-2 border-white/30 transition-colors text-center"
@@ -863,7 +863,7 @@ import logo from '../assets/logo.png';
           href="/registrer"
           class="bg-white text-blue-900 px-8 py-4 rounded-lg font-semibold text-lg hover:bg-blue-50 transition transform hover:scale-105 shadow-xl"
         >
-          Kom i gang nå
+          Bestill nå
         </a>
         <a
           href="https://test.export.fish"


### PR DESCRIPTION
## Summary
Updates the primary call-to-action button text on the homepage to be more direct and action-oriented.

## Changes
- Changed "Kom i gang nå" → "Bestill nå" in hero section (line 79)
- Changed "Kom i gang nå" → "Bestill nå" in bottom CTA section (line 866)

## Test Plan
- [x] Verify both CTA buttons now say "Bestill nå"
- [x] Visual regression check will run automatically

Fixes #124