### PR TITLE
Fix #132: Auto-scroll to quiz container after answering

### DIFF
--- a/src/pages/registrering.astro
+++ b/src/pages/registrering.astro
@@ -170,6 +170,11 @@ import Layout from '../layouts/Layout.astro';
           resultJa?.classList.add('hidden');
           updateHeader('nei');
         }
+
+        // Scroll to top of quiz container after header updates
+        setTimeout(() => {
+          quizCard?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }, 100);
       }
 
       function resetQuiz() {


### PR DESCRIPTION
Fixes #132

Adds smooth scroll to quiz container when results are displayed, so users can see the results header after the container height changes.

## Changes
- Added `scrollIntoView` call in `showResult()` function with 100ms delay
- Uses smooth scrolling behavior for better UX
- Scrolls to start of quiz container to show updated header and results

## Test Plan
- Navigate to `/registrering#skal-jeg-registrere`
- Answer quiz questions
- Click "Se resultat"
- Verify page smoothly scrolls to show the updated header and result message