### PR TITLE
Simplify registration text for better user understanding

### DIFF
--- a/src/pages/registrer.astro
+++ b/src/pages/registrer.astro
@@ -31,7 +31,7 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
             <svg class="w-5 h-5 text-green-600 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
               <path d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" fill-rule="evenodd"></path>
             </svg>
-            <span>Din egen app-instans på eget subdomene (f.eks. dittfirma.export.fish) som du deler med turistene</span>
+            <span>Du får en unik web adresse (f.eks. dittfirma.export.fish) som du deler med turistene</span>
           </li>
           <li class="flex items-start gap-2">
             <svg class="w-5 h-5 text-green-600 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">


### PR DESCRIPTION
## Summary
- Simplified the subdomain explanation text on the registration page
- Changed from technical jargon to user-friendly language

## Changes
**Before:** "Din egen app-instans på eget subdomene (f.eks. dittfirma.export.fish) som du deler med turistene"

**After:** "Du får en unik web adresse (f.eks. dittfirma.export.fish) som du deler med turistene"

## Rationale
The original text used technical terms like "app-instans" and "subdomene" that may be confusing for fishing business owners who aren't tech-savvy. The new text is clearer and more accessible.

Fixes #137