### PR TITLE
Add signature usage terms to vilkår

### DIFF
--- a/src/content/legal/vilkar.md
+++ b/src/content/legal/vilkar.md
@@ -46,7 +46,10 @@ Data behandles for å oppfylle lovpålagt rapporteringsplikt i henhold til Forsk
 ### 4.4 Datadeling
 Fangstdata rapporteres automatisk til Fiskeridirektoratet i henhold til lovkrav. Data deles ikke med andre tredjeparter uten ditt samtykke.
 
-### 4.5 Brukerrettigheter
+### 4.5 Bruk av signatur
+Den håndskrevne signaturen som samles inn under registrering brukes på utførselsdokumentasjon generert av tjenesten. Signaturen vil kun brukes til utstedelse av eksportdokumenter for turister. Annen bruk av signaturen er ikke tillatt.
+
+### 4.6 Brukerrettigheter
 I henhold til GDPR har turistene rett til:
 - Innsyn i egne registrerte data.
 - Retting av uriktige opplysninger.


### PR DESCRIPTION
## Summary
- Added explicit terms about signature collection and usage to the terms of service
- Provides transparency about how handwritten signatures are used
- Limits signature usage to export documentation only

## Changes

### New Section 4.5: Bruk av signatur
Added to the "Databehandling og personvern" section:

> Den håndskrevne signaturen som samles inn under registrering brukes på utførselsdokumentasjon generert av tjenesten. Signaturen vil kun brukes til utstedelse av eksportdokumenter for turister. Annen bruk av signaturen er ikke tillatt.

### Structural Update
- Renumbered existing section 4.5 "Brukerrettigheter" to 4.6 to accommodate the new section

## Rationale

**Transparency**: Users should know exactly how their signature will be used

**Limited scope**: Explicitly states signature is ONLY used for export documentation

**Trust**: Clear terms build confidence in the service and comply with privacy best practices

**GDPR alignment**: Explicit purpose limitation for personal data processing

Fixes #139