### PR TITLE
Add 1 month free trial period messaging

### DIFF
--- a/src/content/legal/vilkar.md
+++ b/src/content/legal/vilkar.md
@@ -135,28 +135,35 @@ Ved oppsigelse:
 ### 9.1 Årlig abonnement
 Tjenesten leveres som et årlig abonnement til en pris på **990,- NOK per år (eksklusiv merverdiavgift)** per turistfiskebedrift.
 
-### 9.2 Fakturering
+### 9.2 Prøveperiode
+- Nye bedrifter får 1 måned gratis prøveperiode.
+- Full tilgang til alle funksjoner i prøveperioden.
+- Ingen betalingsforpliktelse i prøveperioden.
+- Første faktura sendes ved prøveperiodens slutt (30 dager etter aktivering).
+- For å avslutte før prøveperiodens slutt, kontakt oss via vårt [kontaktskjema](/kontakt).
+
+### 9.3 Fakturering
 - Faktureringen starter når bedriften aktiveres og kan ta i bruk tjenesten.
 - Faktura sendes årlig til registrert driftskontakt via e-post.
 - Betalingsfrist er 14 dager fra fakturadato.
 - Betaling skjer via faktura eller avtalt betalingsløsning.
 
-### 9.3 Merverdiavgift
+### 9.4 Merverdiavgift
 Alle priser er oppgitt eksklusiv merverdiavgift (mva). Gjeldende norsk mva-sats legges til på faktura.
 
-### 9.4 Prisendringer
+### 9.5 Prisendringer
 Vi forbeholder oss retten til å justere prisene med 30 dagers skriftlig varsel. Ved prisøkning har du rett til å si opp abonnementet før den nye prisen trer i kraft.
 
-### 9.5 Forsinket betaling
+### 9.6 Forsinket betaling
 Ved forsinket betaling:
 - Påløper forsinkelsesrente i henhold til norsk lov.
 - Kan tilgangen til tjenesten suspenderes inntil betaling er mottatt.
 - Kan inkassosak iverksettes for ubetalt faktura.
 
-### 9.6 Ingen bindingstid
+### 9.7 Ingen bindingstid
 Abonnementet har ingen bindingstid. Du kan si opp abonnementet når som helst med virkning fra neste faktureringsperiode.
 
-### 9.7 Hva er inkludert
+### 9.8 Hva er inkludert
 Årsprisen inkluderer:
 - Ubegrenset antall turistperioder og fangstregistreringer.
 - Automatisk rapportering til Fiskeridirektoratet.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -684,6 +684,50 @@ import logo from '../assets/logo.png';
           </div>
         </details>
 
+        <!-- FAQ 6.5 - Free Trial -->
+        <details class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden group">
+          <summary class="cursor-pointer px-6 py-5 font-semibold text-lg text-gray-900 hover:bg-gray-50 transition-colors list-none flex justify-between items-center">
+            <span>Hvordan fungerer prøveperioden?</span>
+            <svg class="w-5 h-5 text-gray-500 transition-transform group-open:rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+            </svg>
+          </summary>
+          <div class="px-6 py-4 text-gray-600 border-t border-gray-100">
+            <p class="mb-3">
+              Alle nye bedrifter får <strong>1 måned gratis prøveperiode</strong> med full tilgang til alle funksjoner.
+            </p>
+            <ul class="space-y-2">
+              <li class="flex items-start gap-2">
+                <svg class="w-5 h-5 text-green-600 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" fill-rule="evenodd"></path>
+                </svg>
+                <span>Ingen betalingsforpliktelse i de første 30 dagene</span>
+              </li>
+              <li class="flex items-start gap-2">
+                <svg class="w-5 h-5 text-green-600 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" fill-rule="evenodd"></path>
+                </svg>
+                <span>Full tilgang til automatisk rapportering og alle funksjoner</span>
+              </li>
+              <li class="flex items-start gap-2">
+                <svg class="w-5 h-5 text-green-600 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" fill-rule="evenodd"></path>
+                </svg>
+                <span>Første faktura sendes automatisk etter 30 dager (990,- NOK eks. mva)</span>
+              </li>
+              <li class="flex items-start gap-2">
+                <svg class="w-5 h-5 text-green-600 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" fill-rule="evenodd"></path>
+                </svg>
+                <span>Kan avsluttes når som helst via vårt <a href="/kontakt" class="text-primary hover:underline">kontaktskjema</a></span>
+              </li>
+            </ul>
+            <p class="mt-3 text-sm">
+              Dette gir deg mulighet til å teste tjenesten risikofritt og se hvordan den passer inn i din virksomhet før du betaler.
+            </p>
+          </div>
+        </details>
+
         <!-- FAQ 7 -->
         <details class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden group">
           <summary class="cursor-pointer px-6 py-5 font-semibold text-lg text-gray-900 hover:bg-gray-50 transition-colors list-none flex justify-between items-center">

--- a/src/pages/registrer.astro
+++ b/src/pages/registrer.astro
@@ -23,6 +23,19 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
         Fyll ut skjemaet under for å komme i gang med export.fish. Vi setter opp alt du trenger for digital fangstrapportering.
       </p>
 
+      <!-- Free Trial Banner -->
+      <div class="bg-gradient-to-r from-green-500 to-emerald-600 text-white rounded-xl shadow-lg p-6 max-w-3xl mx-auto mb-8">
+        <div class="flex items-center justify-center gap-3 mb-2">
+          <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+          </svg>
+          <h2 class="text-2xl font-bold">Prøv gratis i 1 måned</h2>
+        </div>
+        <p class="text-center text-green-50 text-lg">
+          Full tilgang til alle funksjoner – ingen binding, ingen betalingskort påkrevd
+        </p>
+      </div>
+
       <!-- Benefits List -->
       <div class="bg-white rounded-xl shadow-md p-6 max-w-3xl mx-auto mt-8">
         <h2 class="text-lg font-semibold text-gray-900 mb-4">Dette får du:</h2>
@@ -280,9 +293,9 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
                 </div>
               </div>
               <div>
-                <h4 class="font-bold text-lg text-gray-900 mb-2">Pris: 990,- NOK per år (eks. mva)</h4>
+                <h4 class="font-bold text-lg text-gray-900 mb-2">1 måned gratis – deretter 990,- NOK per år (eks. mva)</h4>
                 <p class="text-gray-700 text-sm mb-2">
-                  Tilsvarer kun 82,50 kr/mnd. Faktureres årlig når vi legger deg til i systemet.
+                  Risikofritt å prøve! Første faktura sendes etter 30 dager. Tilsvarer kun 82,50 kr/mnd.
                 </p>
                 <ul class="text-gray-700 text-sm space-y-1">
                   <li class="flex items-start gap-2">


### PR DESCRIPTION
## Summary
- Added 1 month free trial period messaging across the website
- Updates terms of service, registration page, and FAQ
- Emphasizes risk-free trial with no credit card required

## Changes

### 1. Terms of Service (vilkar.md)

**Added Section 9.2 "Prøveperiode":**
- Nye bedrifter får 1 måned gratis prøveperiode
- Full tilgang til alle funksjoner i prøveperioden
- Ingen betalingsforpliktelse i prøveperioden
- Første faktura sendes ved prøveperiodens slutt (30 dager etter aktivering)
- For å avslutte før prøveperiodens slutt, kontakt oss via kontaktskjema

**Renumbered subsequent sections** (9.2→9.3, 9.3→9.4, etc.)

### 2. Registration Page (registrer.astro)

**Added prominent free trial banner:**
- Eye-catching green gradient banner with "Prøv gratis i 1 måned"
- Clear messaging: "Full tilgang til alle funksjoner – ingen binding, ingen betalingskort påkrevd"

**Updated pricing box:**
- Headline: "1 måned gratis – deretter 990,- NOK per år (eks. mva)"
- Description: "Risikofritt å prøve! Første faktura sendes etter 30 dager."

### 3. FAQ (index.astro)

**Added new FAQ entry: "Hvordan fungerer prøveperioden?"**
- Explains the 30-day free trial
- Lists all benefits with checkmarks
- Clear cancellation instructions via contact form
- Emphasizes risk-free testing

## Marketing Messaging

Key themes throughout:
- **Risikofritt** (risk-free)
- **Ingen binding** (no commitment)
- **Full tilgang** (full access)
- **Transparent cancellation process**

## User Experience

**Lower barrier to entry:**
- No credit card required to start
- No financial commitment for 30 days
- Clear path to cancel via contact form

**Builds trust:**
- Transparent about automatic billing after trial
- Easy to understand terms
- Professional yet friendly tone

Fixes #143