### PR TITLE
Add NHO Reiseliv resource link to footer

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -954,6 +954,7 @@ import logo from '../assets/logo.png';
           <ul class="space-y-2 text-sm">
             <li><a href="https://www.fiskeridir.no/turistfiske/rapportering-for-turistfiskebedrifter" target="_blank" rel="noopener noreferrer" class="hover:text-primary transition">Fiskeridirektoratet</a></li>
             <li><a href="https://lovdata.no/dokument/SF/forskrift/2017-07-05-1141" target="_blank" rel="noopener noreferrer" class="hover:text-primary transition">Forskrift om rapportering</a></li>
+            <li><a href="https://www.nhoreiseliv.no/bransjer/opplevelser/fisketurisme/" target="_blank" rel="noopener noreferrer" class="hover:text-primary transition">NHO Reiseliv - Fisketurisme</a></li>
           </ul>
         </div>
 


### PR DESCRIPTION
## Summary
Adds a link to NHO Reiseliv's fisketurisme page in the footer's Ressurser (Resources) section.

## Changes
- Added link: https://www.nhoreiseliv.no/bransjer/opplevelser/fisketurisme/
- Positioned as third item in Ressurser list
- Follows same styling as existing resource links

## Benefit
Provides users with additional industry information and resources from NHO Reiseliv about fishing tourism in Norway.