### PR TITLE
Fix 'Les mer om løsningen' button link

### DIFF
--- a/src/pages/registrering.astro
+++ b/src/pages/registrering.astro
@@ -599,9 +599,7 @@ import Layout from '../layouts/Layout.astro';
         </a>
         <a
           class="bg-gray-100 hover:bg-gray-200 text-gray-900 font-semibold text-lg px-8 py-4 rounded-lg transition-colors text-center"
-          href="https://test.export.fish"
-          rel="noopener noreferrer"
-          target="_blank"
+          href="/"
         >
           Les mer om løsningen
         </a>


### PR DESCRIPTION
## Summary

- Fixed the "Les mer om løsningen" button on the `/registrering` page to link to the homepage (`/`) instead of `https://test.export.fish`
- Removed `target="_blank"` and `rel` attributes since this is now an internal navigation
- Button maintains consistent styling and improves user journey flow

## Test plan

- [ ] Navigate to `/registrering` page
- [ ] Click "Les mer om løsningen" button in the CTA section
- [ ] Verify it navigates to the homepage (not test.export.fish)
- [ ] Verify it doesn't open in a new tab
- [ ] Verify button styling remains consistent
- [ ] Build completes successfully

Fixes #157