### PR TITLE
Implement GA4 Consent Mode v2 with Cookie Banner

### DIFF
--- a/src/components/CookieConsent.astro
+++ b/src/components/CookieConsent.astro
@@ -1,0 +1,72 @@
+---
+// Cookie consent banner for GA4 Consent Mode v2
+// No props needed - fully self-contained component
+---
+
+<div id="cookie-consent-banner" class="fixed bottom-0 left-0 right-0 bg-white border-t-2 border-gray-200 shadow-lg p-4 md:p-6 z-50 transform transition-transform duration-300 translate-y-full">
+  <div class="container mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
+    <div class="flex-1">
+      <h3 class="font-semibold text-gray-900 mb-1">Vi bruker informasjonskapsler</h3>
+      <p class="text-sm text-gray-600">Vi bruker Google Analytics for å forbedre nettstedet. Informasjonskapslene hjelper oss å forstå hvordan besøkende bruker siden.</p>
+    </div>
+    <div class="flex gap-3 shrink-0">
+      <button id="cookie-accept" class="bg-primary hover:bg-primary-hover text-white px-6 py-2 rounded-lg transition-colors font-semibold">
+        Godta
+      </button>
+      <button id="cookie-decline" class="bg-gray-200 hover:bg-gray-300 text-gray-700 px-6 py-2 rounded-lg transition-colors font-semibold">
+        Avvis
+      </button>
+    </div>
+  </div>
+</div>
+
+<script>
+  // Check for existing consent on page load
+  function checkConsent() {
+    const consent = localStorage.getItem('cookie-consent');
+    const banner = document.getElementById('cookie-consent-banner');
+
+    if (consent === 'granted') {
+      // Update gtag consent to granted
+      if (typeof gtag !== 'undefined') {
+        gtag('consent', 'update', {
+          'analytics_storage': 'granted',
+          'ad_storage': 'granted'
+        });
+      }
+    } else if (consent === null) {
+      // No consent stored - show banner
+      if (banner) {
+        banner.classList.remove('translate-y-full');
+      }
+    }
+    // If consent is 'denied', banner stays hidden and consent stays denied
+  }
+
+  // Handle consent buttons
+  document.addEventListener('DOMContentLoaded', () => {
+    const banner = document.getElementById('cookie-consent-banner');
+    const acceptBtn = document.getElementById('cookie-accept');
+    const declineBtn = document.getElementById('cookie-decline');
+
+    acceptBtn?.addEventListener('click', () => {
+      localStorage.setItem('cookie-consent', 'granted');
+      if (typeof gtag !== 'undefined') {
+        gtag('consent', 'update', {
+          'analytics_storage': 'granted',
+          'ad_storage': 'granted'
+        });
+      }
+      banner?.classList.add('translate-y-full');
+    });
+
+    declineBtn?.addEventListener('click', () => {
+      localStorage.setItem('cookie-consent', 'denied');
+      // Consent stays denied (already set as default)
+      banner?.classList.add('translate-y-full');
+    });
+
+    // Check consent on load
+    checkConsent();
+  });
+</script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,6 +2,7 @@
 import '../styles/global.css';
 import { getImage } from 'astro:assets';
 import defaultOgImage from '../assets/hero-bg.jpg';
+import CookieConsent from '../components/CookieConsent.astro';
 
 interface Props {
   title: string;
@@ -203,11 +204,22 @@ const ogImageURL = new URL(ogImage.src, siteUrl).href;
       }
     </script>
 
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-TH0VD36D5C"></script>
+    <!-- Google Consent Mode v2 -->
     <script is:inline>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
+
+      // Set default consent to 'denied' (cookieless mode)
+      gtag('consent', 'default', {
+        'analytics_storage': 'denied',
+        'ad_storage': 'denied',
+        'wait_for_update': 500
+      });
+    </script>
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-TH0VD36D5C"></script>
+    <script is:inline>
       gtag('js', new Date());
       gtag('config', 'G-TH0VD36D5C');
     </script>
@@ -256,6 +268,7 @@ const ogImageURL = new URL(ogImage.src, siteUrl).href;
       </nav>
     </header>
     <slot />
+    <CookieConsent />
     <script>
       document.addEventListener('DOMContentLoaded', () => {
         const details = document.getElementById('mobile-menu');


### PR DESCRIPTION
## Summary
Implements GA4 Consent Mode v2 with a Norwegian cookie consent banner to comply with GDPR requirements.

## Changes
- **GA4 Consent Mode v2**: GA starts in "denied" (cookieless) mode by default
- **Cookie Consent Banner**: Clean Norwegian banner with "Godta" (accept) and "Avvis" (decline) options
- **Consent Management**: User choice stored in localStorage and persists across sessions
- **gtag Integration**: Consent state properly updates Google Analytics via gtag consent API

## Technical Details
- Default consent state: `analytics_storage` and `ad_storage` set to 'denied'
- Cookie banner component: `/src/components/CookieConsent.astro`
- Tailwind styling: Mobile responsive, matches site design
- localStorage key: `cookie-consent` (values: 'granted', 'denied', or null)

## Testing
- [x] Build passes successfully
- [x] Banner shows on first visit (no consent stored)
- [x] "Godta" grants consent and updates gtag
- [x] "Avvis" keeps denied state
- [x] Choice persists in localStorage
- [x] Banner respects existing consent on page load
- [x] Mobile responsive design

## Reference
- [Google Consent Mode v2 Documentation](https://developers.google.com/tag-platform/security/guides/consent?consentmode=advanced)

## Preview
The cookie banner will appear at the bottom of the page on first visit with Norwegian text explaining the use of Google Analytics for site improvement.