### PR TITLE
Legg til Meta Pixel med samtykkestyring

### DIFF
--- a/src/components/CookieConsent.astro
+++ b/src/components/CookieConsent.astro
@@ -7,7 +7,7 @@
   <div class="container mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
     <div class="flex-1">
       <h3 class="font-semibold text-gray-900 mb-1">Vi bruker informasjonskapsler</h3>
-      <p class="text-sm text-gray-600">Vi bruker Google Analytics for å forbedre nettstedet. Informasjonskapslene hjelper oss å forstå hvordan besøkende bruker siden.</p>
+      <p class="text-sm text-gray-600">Vi bruker informasjonskapsler for analyse og markedsføring, for å forstå hvordan brukerne bruker siden.</p>
     </div>
     <div class="flex gap-3 shrink-0">
       <button id="cookie-accept" class="bg-primary hover:bg-primary-hover text-white px-6 py-2 rounded-lg transition-colors font-semibold">
@@ -56,6 +56,9 @@
           'analytics_storage': 'granted',
           'ad_storage': 'granted'
         });
+      }
+      if (typeof window.initMetaPixel === 'function') {
+        window.initMetaPixel();
       }
       banner?.classList.add('translate-y-full');
     });

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -228,6 +228,33 @@ const ogImageURL = new URL(ogImage.src, siteUrl).href;
       gtag('config', 'G-TH0VD36D5C');
     </script>
 
+    <!-- Meta Pixel - consent gated via ad_storage -->
+    <script is:inline>
+      // Meta Pixel stub - safe to define before consent
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+
+      // Only init and fire PageView if ad_storage consent is already granted
+      window.initMetaPixel = function() {
+        if (window._metaPixelInitialized) return;
+        window._metaPixelInitialized = true;
+        fbq('init', '2517567592013408');
+        fbq('track', 'PageView');
+      };
+
+      document.addEventListener('DOMContentLoaded', function() {
+        if (localStorage.getItem('cookie-consent') === 'granted') {
+          window.initMetaPixel();
+        }
+      });
+    </script>
+
     <!-- Cloudflare Web Analytics -->
     <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "6674d462a18d4e0bb16ef63c13ace4a9"}'></script>
     <!-- End Cloudflare Web Analytics -->

--- a/src/pages/registrer/index.astro
+++ b/src/pages/registrer/index.astro
@@ -306,6 +306,21 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
         throw new Error('Innsending feilet. Vennligst prøv igjen senere, eller kontakt oss på kontakt@eksportfiske.no.');
       }
 
+      // Fire Meta Pixel Lead event with advanced matching
+      if (typeof fbq === 'function') {
+        const [fn, ...ln] = (validated.data.name || '').trim().split(/\s+/);
+        fbq('track', 'Lead', {}, {
+          eventID: 'lead_' + Date.now(),
+          advanced_matching: {
+            em: validated.data.email?.toLowerCase().trim(),
+            ph: validated.data.phone ? '47' + validated.data.phone : undefined,
+            fn: fn?.toLowerCase(),
+            ln: ln.join(' ')?.toLowerCase() || undefined,
+            country: 'no',
+          }
+        });
+      }
+
       window.location.href = '/registrer/takk';
     } catch (error) {
       console.error('Interest form error:', error);


### PR DESCRIPTION
## Summary
- Meta Pixel (2517567592013408) lagt til i Layout.astro, gated bak cookie-samtykke (ad_storage)
- Piksel initialiseres kun etter at bruker godtar informasjonskapsler
- Avansert matching på /registrer/ – sender e-post, telefon og navn ved Lead-konvertering
- Oppdatert cookie-banner til å nevne analyse og markedsføring

## Test plan
- [ ] Verifiser at Meta Pixel IKKE laster før samtykke gis
- [ ] Godta cookies og sjekk at PageView fyrer i Meta Pixel Helper
- [ ] Send inn interesseskjema og verifiser Lead-event med advanced matching data
- [ ] Avvis cookies og bekreft at ingen piksel-aktivitet skjer