### PR TITLE
feat: add optional org number field to lead interest form

### DIFF
--- a/src/pages/registrer/index.astro
+++ b/src/pages/registrer/index.astro
@@ -73,6 +73,17 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
             helpText="Valgfritt – 8-sifret norsk telefonnummer"
           />
 
+          <!-- Organization Number (optional) -->
+          <FormField
+            label="Organisasjonsnummer"
+            name="organizationNumber"
+            type="text"
+            placeholder="9 siffer (valgfritt)"
+            helpText="Hvis du allerede har det klart"
+            inputMode="numeric"
+            maxlength={9}
+          />
+
           <!-- Campaign Code (optional) -->
           <FormField
             label="Kampanjekode"
@@ -185,6 +196,7 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
       .transform((val) => val.replace(/^(\+47|0047)/, ''))
       .optional()
       .or(z.literal('')),
+    organizationNumber: z.string().regex(/^\d{9}$/, 'Organisasjonsnummer må være 9 siffer').optional().or(z.literal('')),
     campaignCode: z.string().max(50).optional(),
     captcha: z.string().optional(),
   });
@@ -200,6 +212,7 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
   const nameParam = urlParams.get('name');
   const emailParam = urlParams.get('email');
   const phoneParam = urlParams.get('phone');
+  const orgnrParam = urlParams.get('orgnr');
 
   // Pre-populate fields from URL params
   if (nameParam) {
@@ -213,6 +226,11 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
   if (phoneParam) {
     const phoneInput = document.querySelector('[name="phone"]') as HTMLInputElement | null;
     if (phoneInput) phoneInput.value = phoneParam;
+  }
+
+  if (orgnrParam) {
+    const orgnrInput = document.querySelector('[name="organizationNumber"]') as HTMLInputElement | null;
+    if (orgnrInput) orgnrInput.value = orgnrParam;
   }
 
   if (campaignCodeParam) {
@@ -247,6 +265,7 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
     const formData = new FormData(form);
     const phoneValue = (formData.get('phone') as string)?.trim();
     const campaignCodeValue = (formData.get('campaignCode') as string)?.trim();
+    const orgNumberValue = (formData.get('organizationNumber') as string)?.trim();
 
     const rawData: Record<string, any> = {
       name: formData.get('name'),
@@ -254,6 +273,7 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
     };
 
     if (phoneValue) rawData.phone = phoneValue;
+    if (orgNumberValue) rawData.organizationNumber = orgNumberValue;
     if (campaignCodeValue) rawData.campaignCode = campaignCodeValue;
 
     // Get Turnstile token if configured
@@ -285,6 +305,7 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
       email: validated.data.email,
     };
     if (validated.data.phone) payload.phone = validated.data.phone;
+    if (validated.data.organizationNumber) payload.organizationNumber = validated.data.organizationNumber;
     if (validated.data.campaignCode) payload.campaignCode = validated.data.campaignCode;
     if (validated.data.captcha) payload.captcha = validated.data.captcha;
 

--- a/src/pages/registrer/index.astro
+++ b/src/pages/registrer/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import FormField from '../../components/forms/FormField.astro';
+import OrgNumberField from '../../components/forms/OrgNumberField.astro';
 
 const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
 ---
@@ -74,15 +75,7 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
           />
 
           <!-- Organization Number (optional) -->
-          <FormField
-            label="Organisasjonsnummer"
-            name="organizationNumber"
-            type="text"
-            placeholder="9 siffer (valgfritt)"
-            helpText="Hvis du allerede har det klart"
-            inputMode="numeric"
-            maxlength={9}
-          />
+          <OrgNumberField required={false} />
 
           <!-- Campaign Code (optional) -->
           <FormField
@@ -196,7 +189,7 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
       .transform((val) => val.replace(/^(\+47|0047)/, ''))
       .optional()
       .or(z.literal('')),
-    organizationNumber: z.string().regex(/^\d{9}$/, 'Organisasjonsnummer må være 9 siffer').optional().or(z.literal('')),
+    organizationNumber: z.string().regex(/^\d{9}$/, 'Organisasjonsnummer må være nøyaktig 9 siffer').optional().or(z.literal('')),
     campaignCode: z.string().max(50).optional(),
     captcha: z.string().optional(),
   });

--- a/src/pages/registrer/ny-kunde.astro
+++ b/src/pages/registrer/ny-kunde.astro
@@ -431,12 +431,13 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
   const formError = document.getElementById('form-error');
   const formErrorMessage = document.getElementById('form-error-message');
 
-  // Handle pre-fill from URL query parameters (name, email, phone, kampanje)
+  // Handle pre-fill from URL query parameters (name, email, phone, orgnr, kampanje)
   const urlParams = new URLSearchParams(window.location.search);
   const campaignCodeParam = urlParams.get('kampanje');
   const nameParam = urlParams.get('name');
   const emailParam = urlParams.get('email');
   const phoneParam = urlParams.get('phone');
+  const orgnrParam = urlParams.get('orgnr');
 
   // Pre-populate contact fields from URL params
   if (nameParam) {
@@ -456,6 +457,15 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
     const businessPhone = document.querySelector('[name="businessContact.phone"]') as HTMLInputElement | null;
     if (reportingPhone) reportingPhone.value = phoneParam;
     if (businessPhone) businessPhone.value = phoneParam;
+  }
+
+  if (orgnrParam) {
+    const orgnrInput = document.querySelector('[name="organizationNumber"]') as HTMLInputElement | null;
+    if (orgnrInput) {
+      orgnrInput.value = orgnrParam;
+      // Trigger input event to activate Brreg auto-lookup
+      orgnrInput.dispatchEvent(new Event('input'));
+    }
   }
 
   if (campaignCodeParam) {


### PR DESCRIPTION
## Summary
- Add optional organization number field (9 digits) to the lead interest form
- Zod validation: optional, must be exactly 9 digits if provided
- Included in API payload as `organizationNumber`
- Pre-fill support via `?orgnr=` query param on both forms
- Full registration form (`ny-kunde`) auto-triggers Brreg lookup when org number is pre-filled

## Companion PR
Requires matching backend changes in `eik-it/export.fish` (PR eik-it/export.fish/pull/538) to accept the new field and enrich with Brreg/Turistfiske API data.

## Test plan
- [x] Astro build succeeds
- [ ] Verify form renders with optional org number field
- [ ] Verify submission includes org number when provided
- [ ] Verify `/registrer/ny-kunde?orgnr=910337727` triggers Brreg auto-lookup