### PR TITLE
Fjern Soro-attribusjon fra bloggartikler

### DIFF
--- a/scripts/sync-soro-rss.mjs
+++ b/scripts/sync-soro-rss.mjs
@@ -102,9 +102,6 @@ function buildFrontmatter(fields) {
   lines.push(`slug: ${JSON.stringify(fields.slug)}`);
   lines.push(`guid: ${JSON.stringify(fields.guid)}`);
   lines.push(`pubDate: ${fields.pubDate}`);
-  if (fields.source) {
-    lines.push(`source: ${JSON.stringify(fields.source)}`);
-  }
   if (fields.image) {
     lines.push('image:');
     lines.push(`  src: ${JSON.stringify(fields.image.src)}`);
@@ -231,7 +228,6 @@ async function main() {
       slug,
       guid,
       pubDate: pubDateIso,
-      source: 'Soro (trysoro.com)',
       image: imageUrl ? { src: imageUrl, alt: title } : null,
       tags,
     });

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -11,7 +11,6 @@ const legalCollection = defineCollection({
   }),
 });
 
-// Blog collection for Soro-sourced articles
 // Note: the frontmatter `slug` field is consumed by the glob loader as entry.id
 // and must not be declared in the schema.
 const blogCollection = defineCollection({
@@ -21,7 +20,6 @@ const blogCollection = defineCollection({
     description: z.string(),
     guid: z.string(),
     pubDate: z.coerce.date(),
-    source: z.string().optional(),
     image: z
       .object({
         src: z.string(),

--- a/src/pages/blogg/[...slug].astro
+++ b/src/pages/blogg/[...slug].astro
@@ -91,15 +91,6 @@ const jsonLd = {
       <div class="article-body text-gray-800 leading-relaxed">
         <Content />
       </div>
-
-      <!-- Source attribution -->
-      {entry.data.source && (
-        <footer class="mt-10 pt-6 border-t border-gray-200">
-          <p class="text-sm text-gray-500">
-            Publisert via Soro, redigert for eksportfiske.no
-          </p>
-        </footer>
-      )}
     </div>
   </article>
 


### PR DESCRIPTION
## Summary
Fjerner synlig attribusjon av Soro som innholdsleverandør.

- Skjema: `source`-felt fjernet fra `blog`-collection
- Detaljside: attribusjons-footer fjernet
- Sync-skript: skriver ikke lenger `source`-felt i frontmatter

Basert på master, som allerede inkluderer #180.

## Test plan
- [ ] `npm run build` grønn (verifisert lokalt: 10 sider)
- [ ] Etter merge: dispatcher Soro-workflow manuelt og bekrefter at ny PR opprettes uten `source` i frontmatter og uten footer på artikkelen