### PR TITLE
Hopp over visual regression for rene blogg-endringer

### DIFF
--- a/.github/workflows/visual-regression-screenshots.yml
+++ b/.github/workflows/visual-regression-screenshots.yml
@@ -4,6 +4,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - 'src/**'
+      - '!src/content/blog/**'
       - 'public/**'
       - 'e2e/**'
       - 'astro.config.mjs'


### PR DESCRIPTION
## Summary
Legger til et negativt path-filter i visual-regression-workflowen slik at PR-er som kun endrer `src/content/blog/**` ikke trigger screenshot-jobben.

Blogg-markdown påvirker ikke UI-komponenter eller styling — visual regression gir ingen verdi her, bare kø-tid og støy.

## Semantikk
- PR som kun endrer `src/content/blog/**.md` → workflow hoppes over (Soro-PR-er, manuelle innholds-PR-er)
- PR som endrer både blogg-innhold og `src/`-kode → workflow kjører som før
- PR uten blogg-endringer → workflow kjører som før

GitHub tillater ikke `paths` og `paths-ignore` samtidig, derfor negativt mønster (`!src/content/blog/**`) i `paths`-lista.

## Test plan
- [ ] Etter merge: når Soro-workflow oppretter neste PR, bekreft at `Generate Visual Regression Screenshots` ikke kjører
- [ ] En vanlig kode-PR som endrer `src/pages/*.astro` trigger fortsatt workflowen