### PR TITLE
Last ned bloggbilder lokalt

### DIFF
--- a/scripts/sync-soro-rss.mjs
+++ b/scripts/sync-soro-rss.mjs
@@ -19,6 +19,7 @@ const FEED_URL = 'https://app.trysoro.com/api/rss/11cc0329-e7c8-46bf-aa54-faa04e
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = join(__dirname, '..');
 const blogDir = join(projectRoot, 'src', 'content', 'blog');
+const imagesDir = join(blogDir, 'images');
 
 if (!existsSync(blogDir)) {
   mkdirSync(blogDir, { recursive: true });
@@ -50,6 +51,30 @@ function createTurndown() {
     bulletListMarker: '-',
   });
   return td;
+}
+
+// Download a remote image and return its extension. Throws on network/HTTP error.
+async function downloadImage(url, slug) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+  // Infer extension from URL path, fall back to content-type, then to webp.
+  const urlPath = new URL(url).pathname;
+  const urlExt = urlPath.match(/\.(webp|jpe?g|png|gif|avif)$/i)?.[1]?.toLowerCase();
+  const ctypeExt = {
+    'image/webp': 'webp',
+    'image/jpeg': 'jpg',
+    'image/png': 'png',
+    'image/gif': 'gif',
+    'image/avif': 'avif',
+  }[res.headers.get('content-type')?.split(';')[0].trim()];
+  const ext = urlExt || ctypeExt || 'webp';
+
+  if (!existsSync(imagesDir)) mkdirSync(imagesDir, { recursive: true });
+  const target = join(imagesDir, `${slug}.${ext}`);
+  const buf = Buffer.from(await res.arrayBuffer());
+  writeFileSync(target, buf);
+  return `./images/${slug}.${ext}`;
 }
 
 // Extract a clean slug from the item link
@@ -219,6 +244,17 @@ async function main() {
     const imageUrl = extractImageUrl(item);
     const tags = extractTags(item);
 
+    // Download hero image to src/content/blog/images/<slug>.<ext>
+    // so Astro's image pipeline can optimize it (AVIF/WebP + srcset).
+    let localImagePath = null;
+    if (imageUrl) {
+      try {
+        localImagePath = await downloadImage(imageUrl, slug);
+      } catch (err) {
+        console.log(`  Could not download image for "${slug}": ${err.message}`);
+      }
+    }
+
     const htmlBody = item['content:encoded'] || '';
     const markdownBody = htmlBody ? turndown.turndown(htmlBody) : '';
 
@@ -228,7 +264,7 @@ async function main() {
       slug,
       guid,
       pubDate: pubDateIso,
-      image: imageUrl ? { src: imageUrl, alt: title } : null,
+      image: localImagePath ? { src: localImagePath, alt: title } : null,
       tags,
     });
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -15,19 +15,20 @@ const legalCollection = defineCollection({
 // and must not be declared in the schema.
 const blogCollection = defineCollection({
   loader: glob({ pattern: '**/*.md', base: './src/content/blog' }),
-  schema: z.object({
-    title: z.string(),
-    description: z.string(),
-    guid: z.string(),
-    pubDate: z.coerce.date(),
-    image: z
-      .object({
-        src: z.string(),
-        alt: z.string(),
-      })
-      .optional(),
-    tags: z.array(z.string()).default([]),
-  }),
+  schema: ({ image }) =>
+    z.object({
+      title: z.string(),
+      description: z.string(),
+      guid: z.string(),
+      pubDate: z.coerce.date(),
+      image: z
+        .object({
+          src: image(),
+          alt: z.string(),
+        })
+        .optional(),
+      tags: z.array(z.string()).default([]),
+    }),
 });
 
 export const collections = {

--- a/src/pages/blogg/[...slug].astro
+++ b/src/pages/blogg/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection, render } from 'astro:content';
+import { Image } from 'astro:assets';
 import Layout from '../../layouts/Layout.astro';
 
 export async function getStaticPaths() {
@@ -40,7 +41,7 @@ const jsonLd = {
     ? {
         image: {
           '@type': 'ImageObject',
-          url: entry.data.image.src,
+          url: new URL(entry.data.image.src.src, siteUrl).toString(),
           description: entry.data.image.alt,
         },
       }
@@ -76,11 +77,11 @@ const jsonLd = {
       <!-- Hero image -->
       {entry.data.image && (
         <figure class="mb-10">
-          <img
+          <Image
             src={entry.data.image.src}
             alt={entry.data.image.alt}
-            width="800"
-            height="450"
+            widths={[480, 800, 1200]}
+            sizes="(max-width: 768px) 100vw, 800px"
             class="w-full rounded-xl object-cover"
             loading="eager"
           />

--- a/src/pages/blogg/index.astro
+++ b/src/pages/blogg/index.astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
+import { Image } from 'astro:assets';
 import Layout from '../../layouts/Layout.astro';
 
 const allPosts = await getCollection('blog');
@@ -36,11 +37,11 @@ function formatDate(date: Date): string {
           <article class="flex flex-col sm:flex-row gap-6 border-b border-gray-100 pb-10">
             {post.data.image && (
               <a href={`/blogg/${post.id}`} class="sm:flex-shrink-0">
-                <img
+                <Image
                   src={post.data.image.src}
                   alt={post.data.image.alt}
-                  width="240"
-                  height="160"
+                  width={480}
+                  height={320}
                   class="w-full sm:w-60 h-40 object-cover rounded-lg"
                   loading="lazy"
                 />


### PR DESCRIPTION
## Summary
Soro-bilder lastes nå ned og hostes lokalt istedenfor å refereres fra Supabase CDN.

- Sync-skriptet laster ned \`<enclosure>\`-bildet til \`src/content/blog/images/<slug>.<ext>\`
- Skjema bruker \`image()\`-hjelperen fra \`astro:content\`
- \`<Image>\`-komponent i detalj- og oversiktsside gir AVIF/WebP + responsiv srcset
- JSON-LD refererer absolutt URL på eget domene

## Hvorfor
- **LCP**: Astro-pipelinen lager 4 størrelser (480w/800w/1200w) og flere formater. Mobil får 19KB istedenfor 68KB.
- **AI/Google SEO**: bilder knyttes til eksportfiske.no, ikke Supabase
- **Robusthet**: artiklene fungerer selv om Soro/Supabase faller ut
- **GDPR**: ingen IP-lekkasje til tredjepart ved bildelasting
- **CLS**: Astro kjenner dimensjoner på byggtid, setter \`width\`/\`height\` automatisk

## Verifisert lokalt
- \`node scripts/sync-soro-rss.mjs\`: lastet ned 68KB webp til \`src/content/blog/images/ma-du-registrere-turistfiskebedrift.webp\`
- \`npm run build\`: 11 sider bygd, 4 bildevarianter generert (19KB/36KB/56KB/73KB)
- \`<img>\`-output har korrekt srcset med 480w/800w/1200w
- JSON-LD image URL: \`https://eksportfiske.no/_astro/ma-du-registrere-turistfiskebedrift.BysEPLoP.webp\`
- Ingen supabase-URL-lekkasjer i dist/

## Viktig — åpen Soro-PR #184 må regenereres
PR #184 har gammel frontmatter (\`image.src: "https://..."\`). Etter merge av denne PR-en vil #184 feile skjemavalidering. Lukk #184 og trigger Soro-workflowen på nytt via \`workflow_dispatch\` etter merge — den vil regenerere artikkelen med lokalt bilde.

## Test plan
- [ ] Merge, deretter lukk #184
- [ ] Dispatch Soro-workflowen manuelt
- [ ] Bekreft at ny PR inneholder både \`.md\` og \`.webp\` i \`src/content/blog/\`
- [ ] Etter merge av den nye PR-en: sjekk \`/blogg/\` og \`/blogg/<slug>\` i prod