### PR TITLE
OG-bilde per side: bloggartikler bruker eget hero

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -5,22 +5,36 @@ import defaultOgImage from '../assets/hero-bg.jpg';
 import CookieConsent from '../components/CookieConsent.astro';
 import logo from '../assets/logo.png';
 
+import type { ImageMetadata } from 'astro';
+
 interface Props {
   title: string;
   description?: string;
   noindex?: boolean;
+  ogImage?: ImageMetadata;
+  ogImageAlt?: string;
+  ogType?: 'website' | 'article';
+  articlePublishedTime?: string;
 }
 
 const {
   title,
   description = 'Enkel fangstrapportering for turistfiskebedrifter',
   noindex = false,
+  ogImage: customOgImage,
+  ogImageAlt,
+  ogType = 'website',
+  articlePublishedTime,
 } = Astro.props;
 
-// Generate optimized OG image
-const ogImage = await getImage({ src: defaultOgImage, format: 'webp', width: 1200, height: 630 });
+// Per-page OG image overrides the site default. Both run through the image
+// pipeline at the 1200x630 size that Facebook/LinkedIn prefer.
+const ogSource = customOgImage ?? defaultOgImage;
+const ogImage = await getImage({ src: ogSource, format: 'webp', width: 1200, height: 630 });
+const ogImageAltText = ogImageAlt ?? 'export.fish - Fangstrapportering for turistfiske';
 
-// Generate hero image for preloading (largest responsive size)
+// Hero preload still points at the site-wide hero — that's the LCP element
+// above the fold on the homepage.
 const heroPreload = await getImage({ src: defaultOgImage, format: 'webp', width: 1920 });
 
 const favicon = '/favicon.svg';
@@ -45,17 +59,18 @@ const ogImageURL = new URL(ogImage.src, siteUrl).href;
     <link rel="canonical" href={canonicalURL} />
 
     <!-- Open Graph -->
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content={ogType} />
     <meta property="og:url" content={canonicalURL} />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:image" content={ogImageURL} />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="export.fish - Fangstrapportering for turistfiske" />
+    <meta property="og:image:alt" content={ogImageAltText} />
     <meta property="og:image:type" content="image/webp" />
     <meta property="og:site_name" content="Eksportfiske.no" />
     <meta property="og:locale" content="nb_NO" />
+    {articlePublishedTime && <meta property="article:published_time" content={articlePublishedTime} />}
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
@@ -63,7 +78,7 @@ const ogImageURL = new URL(ogImage.src, siteUrl).href;
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImageURL} />
-    <meta name="twitter:image:alt" content="export.fish app for fangstrapportering" />
+    <meta name="twitter:image:alt" content={ogImageAltText} />
 
     <!-- Favicons - ICO first for Google Search -->
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />

--- a/src/pages/blogg/[...slug].astro
+++ b/src/pages/blogg/[...slug].astro
@@ -52,6 +52,10 @@ const jsonLd = {
 <Layout
   title={`${entry.data.title} | Eksportfiske.no`}
   description={entry.data.description}
+  ogImage={entry.data.image?.src}
+  ogImageAlt={entry.data.image?.alt}
+  ogType="article"
+  articlePublishedTime={entry.data.pubDate.toISOString()}
 >
   <Fragment slot="head">
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />


### PR DESCRIPTION
## Problem
Når du deler en bloggartikkel på Facebook/LinkedIn/Twitter, vises site-heroen i stedet for artikkelens eget bilde. Layout.astro hardkoder \`og:image\` til \`defaultOgImage\` for alle sider uten overstyringsmulighet.

Dokumentert lokalt:
\`\`\`
$ curl eksportfiske.no/blogg/ma-du-registrere-turistfiskebedrift/ | grep og:image
<meta property="og:image" content="https://eksportfiske.no/_astro/hero-bg.CpNXGaOq_1BWCKH.webp">
\`\`\`

## Fiks
Layout får valgfrie props:
- \`ogImage?: ImageMetadata\` — overstyrer default hero
- \`ogImageAlt?: string\` — egen alt-tekst
- \`ogType?: 'website' | 'article'\` — default fortsatt "website"
- \`articlePublishedTime?: string\` — ISO-dato, setter \`article:published_time\`

Bloggartikler bruker nå sitt eget bilde, setter \`og:type=article\` og inkluderer publiseringstidspunkt.

## Verifisert lokalt
Etter build:
\`\`\`
<meta property="og:type" content="article">
<meta property="og:image" content="https://eksportfiske.no/_astro/ma-du-registrere-turistfiskebedrift.BysEPLoP_Z10lX4D.webp">
<meta property="og:image:alt" content="Må du registrere turistfiskebedrift?">
<meta property="article:published_time" content="2026-04-21T08:37:06.000Z">
\`\`\`

Forsiden er uendret — bruker fortsatt default site-heroen.

## Test plan
- [ ] Etter merge: del en bloggartikkel via [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) og klikk "Scrape Again" for å tvinge re-fetch
- [ ] Bekreft at riktig bilde og tittel vises
- [ ] Del forsiden — bekreft at den fortsatt viser site-heroen