### PR TITLE
Rett produktflyt i artikkel om fangstrapportering

### DIFF
--- a/src/content/blog/lovpalagt-fangstrapportering-fritidsboligeiere.md
+++ b/src/content/blog/lovpalagt-fangstrapportering-fritidsboligeiere.md
@@ -10,72 +10,66 @@ image:
 tags: []
 ---
 
-Når en utenlandsk turist leverer nøklene etter en uke med fiske, er det lett å tenke at jobben er gjort. For mange utleiere begynner imidlertid den mest sårbare delen da - dokumentasjonen. Lovpålagt fangstrapportering fritidsboligeiere må forholde seg til, handler ikke bare om å føre noen tall. Det handler om ansvar, sporbarhet og om å kunne vise at utleien skjer innenfor regelverket.
+Når en utenlandsk turist drar etter en uke med fiske, er det lett å tenke at jobben er gjort. For mange utleiere begynner den mest sårbare delen da — dokumentasjonen. Lovpålagt fangstrapportering handler ikke bare om å føre noen tall. Det handler om ansvar, sporbarhet og å kunne vise at utleien skjer innenfor regelverket.
 
-For hytteeiere og mindre utleiere som tilbyr båt og fiskeopplevelser til turister, har dette blitt et langt viktigere tema enn før. Myndighetene forventer bedre datakvalitet, riktige rapporter og tydelig sammenheng mellom fangst, opphold og eventuell utførsel av fisk. Hvis rutinene er svake, er det fort gjort at noe glipper - selv om intensjonen er god.
+For hytteeiere og mindre utleiere som tilbyr båt og fiskeopplevelser til turister, har dette blitt stadig viktigere. Myndighetene forventer bedre datakvalitet, riktige rapporter og tydelig sammenheng mellom fangst, fiskeperiode og eventuell utførsel av fisk. Hvis rutinene er svake, glipper det — selv om intensjonen er god.
 
 ## Hva betyr lovpålagt fangstrapportering for fritidsboligeiere?
 
-I praksis betyr det at du som leier ut fritidsbolig og båt [til turistfiskere](https://eksportfiske.no/registrer/), må ha kontroll på fangstdata når virksomheten omfattes av rapporteringsplikt. Det holder ikke å be gjesten si fra ved avreise eller skrive noe på et ark i resepsjonen. Opplysningene må samles inn riktig, til rett tid og på en måte som kan brukes videre i rapporteringen.
+I praksis betyr det at du som leier ut fritidsbolig og båt [til turistfiskere](https://eksportfiske.no/registrer/), må ha kontroll på fangstdata når virksomheten omfattes av rapporteringsplikt. Det holder ikke å be turisten si fra ved avreise eller skrive noe på et ark. Opplysningene må samles inn riktig, til rett tid og på en måte som kan brukes videre i rapporteringen.
 
-Det er særlig kombinasjonen av overnatting, båtutleie og turistfiske som gjør dette relevant. Mange mindre aktører tenker fortsatt på seg selv som "bare en hytteeier". Men når du tar betalt for opphold der fiske er en vesentlig del av tilbudet, blir du i praksis en del av en [regulert verdikjede](https://eksportfiske.no/registrering/). Da holder det ikke med uformelle rutiner.
+Det er særlig kombinasjonen av overnatting, båtutleie og turistfiske som gjør dette relevant. Mange mindre aktører tenker fortsatt på seg selv som "bare en hytteeier". Men når du tar betalt for fiskeopplevelser, blir du i praksis en del av en [regulert verdikjede](https://eksportfiske.no/registrering/). Da holder det ikke med uformelle rutiner.
 
-Dette er også grunnen til at mange blir overrasket over hvor mye ansvar som faktisk ligger hos utleier. Turisten kan registrere fangsten, men du må ha et system som sikrer at registreringen faktisk skjer, at dataene er forståelige, og at dokumentasjonen kan følges opp.
+Mange blir overrasket over hvor mye ansvar som faktisk ligger hos utleier. Turisten registrerer fangsten, men du må ha et system som sikrer at det faktisk skjer — og at dokumentasjonen kan følges opp.
 
 ## Hvorfor manuelle rutiner ofte svikter
 
-Papirlister, meldinger på SMS og notater ved utsjekk kan fungere når du har få gjester, godt vær og full oversikt. Problemet oppstår når sesongen blir travel, gjestene kommer fra flere land, og fisket skjer over flere dager med ulike båter og personer. Da øker feilmarginen raskt.
+Papirlister, SMS og notater ved avreise kan fungere når du har få turister og full oversikt. Problemet oppstår når sesongen blir travel, turistene kommer fra flere land, og fisket skjer over flere dager med ulike båter og personer. Da øker feilmarginen raskt.
 
-Vi har selv stått i dette, og vi vet hva som glipper når rapporteringen blir noe man "tar på slutten av uka". Gjestene husker ikke nøyaktig art eller vekt, ansatte tolker notater forskjellig, og avreisedagen blir for hektisk til å rydde opp i mangler. Resultatet er ikke bare merarbeid. Det kan også gi svakere etterlevelse av regelverket.
+Vi har selv stått i dette, og vi vet hva som glipper når rapporteringen blir noe man "tar på slutten av uka". Turistene husker ikke nøyaktig art eller vekt, ansatte tolker notater forskjellig, og avreisedagen er for hektisk til å rydde opp i mangler. Resultatet er merarbeid og svakere etterlevelse.
 
-Manuell håndtering skaper også en annen utfordring: ansvaret blir liggende hos utleier alene. Hvis gjesten skulle registrert noe, men ikke gjorde det, sitter du fortsatt igjen med problemet. Derfor trenger du rutiner som fungerer mens oppholdet pågår, ikke bare når det er over.
+Manuell håndtering skaper også et ansvarsfall: sitter turisten på manglende registrering, sitter du med problemet. Du trenger rutiner som fungerer mens fiskeperioden pågår, ikke bare etter den er over.
 
 ## Hva må du ha kontroll på i praksis?
 
 Selve rapporteringsplikten oppleves ofte som komplisert fordi mange blander fangstregistrering, intern dokumentasjon og eksportdokumentasjon. Dette er nært knyttet sammen, men det er ikke det samme.
 
-Du må først og fremst vite hvem som fisker, når de fisker, og hvilken fangst som tas opp. Deretter må dette knyttes til riktig opphold og riktig leieforhold. Hvis turisten senere skal ha dokumentasjon i forbindelse med utførsel av fisk, må grunnlaget allerede være korrekt. Feil i første ledd følger ofte hele veien videre.
+Du må vite hvem som fisker, når de fisker, og hvilken fangst som tas opp — knyttet til riktig fiskeperiode. Hvis turisten senere skal ha dokumentasjon for utførsel av fisk, må grunnlaget allerede være korrekt. Feil i første ledd følger hele veien videre.
 
-Det betyr at gode rutiner starter før første fisketur. Du bør ha tydelig registrering av gjester, en enkel måte å registrere daglig fangst på, og en prosess for kontroll før oppholdet avsluttes. Hvis du venter til utsjekk, har du i realiteten ventet for lenge.
+Gode rutiner starter ved ankomst. Du bør ha en enkel måte for turisten å registrere daglig fangst på, og en prosess for å kontrollere at fiskeperioden er komplett før den avsluttes. Hvis du venter til avreisedagen, har du ventet for lenge.
 
-## Lovpålagt fangstrapportering fritidsboligeiere bør løse daglig
+## Løs det daglig, ikke ved avreise
 
-Det mest praktiske grepet er å tenke daglig flyt i stedet for sluttrapport. Daglig rapportering gjør to ting samtidig. Den reduserer risikoen for feil, og den gjør arbeidet mindre belastende for både gjest og utleier.
+Det mest praktiske grepet er å tenke daglig flyt i stedet for sluttrapport. Turisten registrerer dagens fangst mens informasjonen er fersk, på sitt eget språk. Du oppdager avvik tidlig og slipper å jakte på en ukes historikk i siste liten.
 
-For turisten er det enklere å registrere dagens fangst samme dag, på eget språk, mens informasjonen fortsatt er fersk. For utleier betyr det at avvik oppdages tidlig. Mangler det registrering for en dag, kan du følge opp med en gang. Da slipper du å samle inn en ukes historikk i siste liten.
-
-Her er det også stor forskjell på teori og drift. På papiret kan mange systemer se greie ut. I praksis må løsningen være så enkel at gjesten faktisk bruker den uten opplæring. Hvis registreringen oppleves som tung, hopper folk over den. Da hjelper det lite at rutinen finnes.
+I praksis er forskjellen på et system som brukes og et som ikke brukes: enkelhet. Hvis registreringen oppleves som tung, hopper folk over den. Da hjelper det lite at rutinen finnes.
 
 ## Slik lager du en trygg arbeidsflyt
 
-En god arbeidsflyt trenger ikke være komplisert. Den må bare være konsekvent. Før ankomst registrerer du oppholdet og hvem som skal fiske. Ved innsjekk forklarer du kort hvordan fangst rapporteres underveis. Under oppholdet må gjesten kunne registrere enkelt fra mobil. Før avreise kontrollerer du at oppholdet er komplett dokumentert.
+En god arbeidsflyt trenger ikke være komplisert. Den må bare være konsekvent. Ved ankomst forklarer du kort at turisten selv oppretter fiskeperioden og registrerer fangst dag for dag. Underveis kan du følge med og ta tak i avvik. Når turisten avslutter fiskeperioden ved avreise, kontrollerer du og godkjenner — da er grunnlaget klart for rapportering og eksportdokumentasjon.
 
-Det er denne midtfasen mange undervurderer. Hvis systemet ikke følger opp dag for dag, blir du avhengig av hukommelse og manuell oppsamling. Det er sjelden en trygg modell i høysesong.
+Det er midtfasen mange undervurderer. Uten løpende registrering sitter du med hukommelse og manuell oppsamling i høysesong. Det er sjelden en trygg modell.
 
-Samtidig finnes det et viktig forbehold: ikke alle utleiere har samme behov. En liten aktør med få enheter kan klare seg med enklere rutiner enn et større anlegg med mange båter og hyppige utskiftninger. Men uansett størrelse er prinsippet det samme. Rapporteringsarbeidet må være løpende, dokumenterbart og lett å kontrollere.
+Prinsippet er det samme uansett størrelse: rapporteringsarbeidet må være løpende, dokumenterbart og lett å kontrollere.
 
 ## Når regelverk møter gjesteopplevelse
 
-Mange er redde for at strengere rapportering skal gjøre oppholdet dårligere for turistene. Det trenger ikke skje. Tvert imot blir opplevelsen ofte bedre når forventningene er tydelige og verktøyet er enkelt.
+Mange er redde for at rapporteringskrav skal gjøre fiskeopplevelsen dårligere. Det trenger ikke skje. Forventningene blir tydeligere og hverdagen enklere for begge parter når verktøyet er enkelt.
 
-Turister flest ønsker å gjøre ting riktig, men de trenger klare instrukser. Hvis de møter et papirskjema på norsk og får beskjed om å fylle det ut ved avreise, øker usikkerheten. Hvis de derimot får en enkel digital løsning på sitt eget språk, senker det terskelen betydelig.
+Turister flest ønsker å gjøre ting riktig, men de trenger klare instrukser på sitt eget språk. Et papirskjema på norsk ved avreise øker usikkerheten. En enkel digital løsning — norsk, engelsk, tysk — senker terskelen.
 
-Dette er også et punkt der mange utleiere sparer mer tid enn de først tror. Når gjesten selv registrerer fortløpende, slipper du å tolke håndskrift, etterspørre manglende detaljer eller legge inn alt manuelt i etterkant. Du beholder kontrollen, men du flytter selve innsamlingen nærmere kilden.
+Når turisten selv registrerer fortløpende, slipper du å tolke håndskrift, etterspørre manglende detaljer eller legge inn alt manuelt i etterkant. Du beholder kontrollen, men innsamlingen skjer nærmere kilden.
 
 ## Hvor risikoen faktisk ligger
 
-De fleste tenker først på bøter eller formelle reaksjoner. Det er forståelig, men den daglige risikoen er ofte mer praktisk. Dårlig dokumentasjon skaper ekstraarbeid, usikre avklaringer og frustrasjon i møte med gjester som skal reise videre med fisk.
+De fleste tenker først på bøter, men den daglige risikoen er mer praktisk. Dårlig dokumentasjon skaper ekstraarbeid og frustrasjon i møte med turister som skal reise videre med fisk. Én slik situasjon kan ta uforholdsmessig mye tid for en liten utleier.
 
-Hvis fangstgrunnlaget er uklart, blir også senere dokumentasjon svakere. Da risikerer du misforståelser i en situasjon der turisten forventer raske svar. For en liten utleier kan én slik situasjon ta uforholdsmessig mye tid.
-
-I tillegg kommer omdømmedelen. Gjester som opplever at reglene er uklare eller at avreiseprosessen blir vanskelig, sitter sjelden igjen med en bedre totalopplevelse. God rapportering er derfor ikke bare et myndighetskrav. Det er også en del av selve leveransen.
+God rapportering er heller ikke bare et myndighetskrav. Turister som opplever at avreisen blir vanskelig eller reglene uklare, tar det med seg i totalinntrykket. Det er en del av selve leveransen.
 
 ## Enklere etterlevelse krever riktig verktøy
 
-Hvis du driver med utleie til turistfiskere, er det lite å vinne på å bygge egne nødløsninger rundt et regelverk som allerede er krevende. Du trenger et oppsett som er laget for denne typen drift, der fangstrapportering, kontroll og dokumentasjon henger sammen.
+Hvis du driver utleie til turistfiskere, er det lite å vinne på å bygge egne nødløsninger rundt et regelverk som allerede er krevende. Du trenger et oppsett laget for denne typen drift — der fangstrapportering, kontroll og eksportdokumentasjon henger sammen.
 
-Vi bruker derfor en modell der turisten selv registrerer fangsten digitalt underveis, mens du som utleier beholder oversikten og kan kontrollere opplysningene før de går videre. Det gjør lovpålagt rapportering lettere å gjennomføre i praksis, særlig for mindre aktører som ikke har tid til administrasjon ved siden av den daglige driften.
+Det er akkurat det eksportfiske.no er bygget for. Du deler en lenke med turistene ved ankomst. De oppretter fiskeperioden og registrerer fangst dag for dag på sitt eget språk. Når de avslutter perioden, kontrollerer du og godkjenner — og rapporten går automatisk til Fiskeridirektoratet. Ingen dobbeltarbeid, ingen håndskrift å tolke etterpå.
 
-Poenget er ikke å digitalisere for digitaliseringens skyld. Poenget er å redusere feil, gjøre etterlevelse enklere og gi deg en arbeidshverdag der rapportering faktisk lar seg gjennomføre uten dobbeltarbeid.
-
-For fritidsboligeiere som [leier ut til turistfiske](https://eksportfiske.no/registrer/ny-kunde/), blir dette stadig mindre et spørsmål om hva som er "greit å ha". Det er en del av grunnmuren i driften. Jo tidligere du får på plass en enkel og trygg rutine, desto mindre sårbar blir sesongen når tempoet øker.
+For fritidsboligeiere som [leier ut til turistfiske](https://eksportfiske.no/registrer/ny-kunde/), er dette ikke lenger "greit å ha". Det er en del av grunnmuren. Jo tidligere du får rutinen på plass, desto mindre sårbar blir sesongen når tempoet øker.


### PR DESCRIPTION
## Summary
Den andre Soro-artikkelen beskrev funksjoner som ikke finnes i eksportfiske.no. [Skribent] har gjort en full redigeringsgjennomgang som retter faktafeil og strammer voice samtidig.

## Faktafeil som er rettet
1. **"opphold og leieforhold"** → **"fiskeperiode"** — produktet sporer fiskeperioder, ikke booking-opphold
2. **"tydelig registrering av gjester"** — utleier registrerer ikke gjester; turisten oppretter fiskeperioden selv via lenke
3. **Arbeidsflyt-avsnittet** — erstattet "Før ankomst registrerer du oppholdet", "Ved innsjekk", "Før avreise kontrollerer du" med korrekt flyt: lenke ved ankomst → turisten oppretter/registrerer → turisten avslutter perioden → utleier godkjenner

## Andre endringer
- "gjesten/gjester" → "turisten/turistene" gjennomgående
- "innsjekk/utsjekk" → "ankomst/avreise"
- Produkt-CTA på slutten er nå konkret: "Du deler en lenke med turistene ved ankomst. De oppretter fiskeperioden og registrerer fangst dag for dag på sitt eget språk. Når de avslutter perioden, kontrollerer du og godkjenner — og rapporten går automatisk til Fiskeridirektoratet."
- ~25% kortere (fjernet fyllstoff)

## Test plan
- [ ] Les artikkelen i preview og bekreft at flyten matcher faktisk produkt
- [ ] Ingen gjenværende referanser til "opphold", "innsjekk", "utsjekk" utenfor overskrifter/kontekst