### PR TITLE
Oppgrader Node til 22 i CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/soro-rss-sync.yml
+++ b/.github/workflows/soro-rss-sync.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Installer avhengigheter
         run: npm ci


### PR DESCRIPTION
## Summary
- Astro nå krever Node >=22.12.0, men CI-workflowene kjørte på Node 20
- Oppgraderer `deploy.yml` og `soro-rss-sync.yml` til Node 22
- Løser build-feilen som slår inn på master: "Node.js v20.20.2 is not supported by Astro!"

## Test plan
- [ ] Deploy-workflow kjører grønn på denne PR-en
- [ ] Soro RSS sync-workflow kjører grønn neste schedule (eller manuell dispatch)