### PR TITLE
Fjern misvisende påstand om per-båt-rapportering i blogartikkel

### DIFF
--- a/src/content/blog/daglig-fangstrapportering-turistfiske.md
+++ b/src/content/blog/daglig-fangstrapportering-turistfiske.md
@@ -3,20 +3,20 @@ title: "Daglig fangstrapportering i turistfiske"
 description: "Regelverket krever daglig fangstrapportering i turistfiske. Slik gjør du rapporteringen enkel, riktig og trygg for gjestene."
 slug: "daglig-fangstrapportering-turistfiske"
 guid: "8dc94a43-733f-492c-84da-31661f4f9559"
-pubDate: 2026-04-21T19:50:39.000Z
+pubDate: 2026-04-22T19:50:39.000Z
 image:
   src: "./images/daglig-fangstrapportering-turistfiske.webp"
   alt: "Daglig fangstrapportering i turistfiske"
 tags: []
 ---
 
-Regelverket krever daglig fangstrapportering. For deg som leier ut hytte og båt til fisketurister, betyr dette at fangst må inn hver dag, per fartøy og art. Det høres kanskje ut som enda mer papirarbeid, men i praksis handler det om å lage en rutine som faktisk fungerer når du har gjester, nøkkelutlevering, båtvask og alt det andre som også skal gjøres.
+Regelverket krever daglig fangstrapportering. For deg som leier ut hytte og båt til fisketurister, betyr dette at fangst må inn hver dag, per opphold og art. Det høres kanskje ut som enda mer papirarbeid, men i praksis handler det om å lage en rutine som faktisk fungerer når du har gjester, nøkkelutlevering, båtvask og alt det andre som også skal gjøres.
 
 Det er nettopp her mange små utleiere kjenner at det glipper. Ikke fordi de ikke vil gjøre ting riktig, men fordi manuelle løsninger er sårbare. En lapp på kjøkkenbordet blir borte. En SMS blir ikke fulgt opp. Gjestene drar tidlig på morgenen, og plutselig mangler du registrering for én av dagene, og du kan ikke avslutte og godkjenne fiskeperioden — som er grunnlaget for [utførselsdokumentasjonen](https://eksportfiske.no/registrer/). Vi har selv stått i dette, og vi vet hvor fort en liten glipp blir til unødvendig stress.
 
 ## Hva betyr daglig fangstrapportering i turistfiske i praksis?
 
-Kjernen er enkel: fangsten skal rapporteres daglig, og rapporteringen skal knyttes til riktig fartøy og riktig art. Det er ikke nok å vite at "de fikk litt torsk og sei i løpet av uka". Du må ha strukturerte opplysninger som kan sendes inn i tråd med kravene.
+Kjernen er enkel: fangsten skal rapporteres daglig, og rapporteringen skal knyttes til riktig opphold og riktig art. Det er ikke nok å vite at "de fikk litt torsk og sei i løpet av uka". Du må ha strukturerte opplysninger som kan sendes inn i tråd med kravene.
 
 For en liten utleier med én hytte og én båt betyr dette at du må vite hva gjestene faktisk har tatt opp hver dag de fisker. Har du flere hytter eller overlappende opphold, må du i tillegg passe på at fangsten knyttes til riktig gjest og riktig periode. Det er her mange undervurderer arbeidsmengden. Selve rapporten trenger ikke ta lang tid, men oppfølgingen rundt kan spise tid hvis du må ringe, purre og etterregistrere.
 

--- a/src/content/blog/daglig-fangstrapportering-turistfiske.md
+++ b/src/content/blog/daglig-fangstrapportering-turistfiske.md
@@ -12,7 +12,7 @@ tags: []
 
 Regelverket krever daglig fangstrapportering. For deg som leier ut hytte og båt til fisketurister, betyr dette at fangst må inn hver dag, per opphold og art. Det høres kanskje ut som enda mer papirarbeid, men i praksis handler det om å lage en rutine som faktisk fungerer når du har gjester, nøkkelutlevering, båtvask og alt det andre som også skal gjøres.
 
-Det er nettopp her mange små utleiere kjenner at det glipper. Ikke fordi de ikke vil gjøre ting riktig, men fordi manuelle løsninger er sårbare. En lapp på kjøkkenbordet blir borte. En SMS blir ikke fulgt opp. Gjestene drar tidlig på morgenen, og plutselig mangler du registrering for én av dagene, og du kan ikke avslutte og godkjenne fiskeperioden — som er grunnlaget for [utførselsdokumentasjonen](https://eksportfiske.no/registrer/). Vi har selv stått i dette, og vi vet hvor fort en liten glipp blir til unødvendig stress.
+Det er nettopp her mange små utleiere kjenner at det glipper. Ikke fordi de ikke vil gjøre ting riktig, men fordi manuelle løsninger er sårbare. En lapp på kjøkkenbordet blir borte. En SMS blir ikke fulgt opp. Gjestene drar tidlig på morgenen, og plutselig mangler du registrering for én av dagene, og du kan ikke avslutte og godkjenne fiskeperioden — som er grunnlaget for utførselsdokumentasjonen. Vi har selv stått i dette, og vi vet hvor fort en liten glipp blir til unødvendig stress.
 
 ## Hva betyr daglig fangstrapportering i turistfiske i praksis?
 
@@ -62,7 +62,7 @@ Mange som driver med [én hytte og én båt](https://eksportfiske.no/blogg/lovpa
 
 Når du driver alene eller sammen med familien, må systemet fungere uten opplæring, installasjon og teknisk styr. Det må være lett å sette i gang med, lett å bruke for gjestene og lett å kontrollere for deg. Det er også derfor lav terskel betyr så mye mer enn "fine funksjoner". Hvis løsningen ikke blir brukt hver dag, hjelper det lite hva den kan på papiret.
 
-Vi mener derfor at god daglig fangstrapportering turistfiske ikke først og fremst handler om avansert teknologi. Det handler om å fjerne friksjon. En løsning der turisten enkelt får tilgang via e-post og kan registrere på sitt eget språk er ofte mer verdifull enn et komplisert system med mange valg. Når det er enkelt, blir det gjort.
+Vi mener derfor at god daglig fangstrapportering turistfiske ikke først og fremst handler om avansert teknologi. Det handler om å fjerne friksjon. En løsning der turisten enkelt får tilgang via e-post og kan registrere på sitt eget språk er ofte mer verdifull enn et komplisert system med mange valg. Når det er enkelt, blir det gjort. Det er akkurat derfor [eksportfiske.no gjør rapporteringen enkel](https://eksportfiske.no/registrer/ny-kunde/) — turistene registrerer på eget språk via en e-postlenke, og du beholder kontrollen før utførselsdokumentasjonen utstedes.
 
 ## Hvordan gjøre oppstarten enkel for gjestene
 
@@ -81,3 +81,9 @@ Et annet tydelig tegn er at du har begynt å få flere korte opphold. Jo oftere 
 Vi nevner ikke dette for å dramatisere. Tvert imot. Poenget er at du kan ta grep før det blir et problem. Når rapporteringen går digitalt og løpende, får du en enklere hverdag og bedre kontroll uten å bruke mer tid.
 
 For mange små utleiere er det nettopp det som teller mest. Ikke store ord, men en løsning som gjør at dagen flyter. Du vet at kravene følges. Gjestene forstår hva de skal gjøre. Og når de skal reise hjem, ligger grunnlaget klart i stedet for å være noe du må jage inn i siste liten.
+
+## Kom i gang med enkel daglig rapportering
+
+eksportfiske.no har vi laget for små utleiere som vil ha rutinen på plass uten å investere i et stort system. Turistene registrerer fangsten på sitt eget språk via en unik e-postlenke, du godkjenner fiskeperioden før avreise, og utførselsdokumentasjonen ligger klar.
+
+[Registrer bedriften din i dag →](https://eksportfiske.no/registrer/ny-kunde/)

--- a/src/content/blog/daglig-fangstrapportering-turistfiske.md
+++ b/src/content/blog/daglig-fangstrapportering-turistfiske.md
@@ -18,7 +18,7 @@ Det er nettopp her mange små utleiere kjenner at det glipper. Ikke fordi de ikk
 
 Kjernen er enkel: fangsten skal rapporteres daglig, og rapporteringen skal knyttes til riktig fartøy og riktig art. Det er ikke nok å vite at "de fikk litt torsk og sei i løpet av uka". Du må ha strukturerte opplysninger som kan sendes inn i tråd med kravene.
 
-For en liten utleier med én hytte og én båt betyr dette at du må vite hva gjestene faktisk har tatt opp hver dag de fisker. Har du to båter, må du i tillegg passe på at fangsten blir ført på riktig båt. Det er her mange undervurderer arbeidsmengden. Selve rapporten trenger ikke ta lang tid, men oppfølgingen rundt kan spise tid hvis du må ringe, purre og etterregistrere.
+For en liten utleier med én hytte og én båt betyr dette at du må vite hva gjestene faktisk har tatt opp hver dag de fisker. Har du flere hytter eller overlappende opphold, må du i tillegg passe på at fangsten knyttes til riktig gjest og riktig periode. Det er her mange undervurderer arbeidsmengden. Selve rapporten trenger ikke ta lang tid, men oppfølgingen rundt kan spise tid hvis du må ringe, purre og etterregistrere.
 
 Det nye kravet gjør også noe annet viktig: det flytter rapportering fra "noe vi ordner ved utsjekk" til "noe som må skje løpende". Da holder det ikke med gode intensjoner. Du trenger en rutine som er enkel nok til at både du og gjestene faktisk bruker den hver dag.
 
@@ -44,7 +44,7 @@ Til slutt trenger du en kontrollsløyfe. Selv om turistene registrerer selv, må
 
 Det er særlig tre ting som ofte skaper trøbbel. Det første er artsregistrering. Gjestene bruker gjerne ord de kjenner fra hjemlandet, eller de skiller ikke mellom arter som du vet må føres korrekt. Derfor bør systemet hjelpe dem til å velge riktig art, ikke overlate alt til fritekst.
 
-Det andre er fartøy. Hvis du leier ut mer enn én båt, må fangsten kobles til riktig båt fra start. Det er tungvint å rydde opp i etterkant, og det er fort gjort å blande hvis to grupper kommer inn omtrent samtidig.
+Det andre er opphold og gjester. Hvis du har flere hytter eller grupper som overlapper, må fangsten knyttes til riktig opphold fra start. Det er tungvint å rydde opp i etterkant, og det er fort gjort å blande hvis to grupper kommer inn omtrent samtidig.
 
 Det tredje er timing. Mange tenker at så lenge alt er ført før gjestene drar, er det godt nok. Men med daglige krav og avhengighet mellom rapportering og utførselsdokumentasjon blir det en dårlig vane. Den tryggeste løsningen er å få fangsten registrert fortløpende hver dag.
 


### PR DESCRIPTION
## Endring

To setninger i bloggartikkelen om daglig fangstrapportering hevdet at fangst må kobles til riktig båt. Dette er i direkte konflikt med:

- Sideens eget FAQ som sier at all fangst rapporteres samlet uavhengig av båt/hytte
- Turistfiske-API-ets datamodell (bedrift → camp → opphold → tur → fangst), som ikke har noe båt-/fartøyfelt

Begge setningene er erstattet med formuleringer som speiler det systemet faktisk støtter: sporing per opphold og gjest.

## Før / etter

**Linje 21 (tidligere):**
> Har du to båter, må du i tillegg passe på at fangsten blir ført på riktig båt.

**Linje 21 (nå):**
> Har du flere hytter eller overlappende opphold, må du i tillegg passe på at fangsten knyttes til riktig gjest og riktig periode.

**Linje 47 (tidligere):**
> Det andre er fartøy. Hvis du leier ut mer enn én båt, må fangsten kobles til riktig båt fra start.

**Linje 47 (nå):**
> Det andre er opphold og gjester. Hvis du har flere hytter eller grupper som overlapper, må fangsten knyttes til riktig opphold fra start.

## Validering

Produksjonsbygg kjørt lokalt — 13 sider bygget uten feil.