### PR TITLE
Forbedre CTA og innbyrdes lenker mellom bloggartiklene

### DIFF
--- a/src/content/blog/daglig-fangstrapportering-turistfiske.md
+++ b/src/content/blog/daglig-fangstrapportering-turistfiske.md
@@ -10,7 +10,7 @@ image:
 tags: []
 ---
 
-Regelverket krever daglig fangstrapportering. For deg som leier ut hytte og båt til fisketurister, betyr dette at fangst må inn hver dag, per opphold og art. Det høres kanskje ut som enda mer papirarbeid, men i praksis handler det om å lage en rutine som faktisk fungerer når du har gjester, nøkkelutlevering, båtvask og alt det andre som også skal gjøres.
+Regelverket krever daglig fangstrapportering [for turistfiskebedrifter](/blogg/ma-du-registrere-turistfiskebedrift/). For deg som leier ut hytte og båt til fisketurister, betyr dette at fangst må inn hver dag, per opphold og art. Det høres kanskje ut som enda mer papirarbeid, men i praksis handler det om å lage en rutine som faktisk fungerer når du har gjester, nøkkelutlevering, båtvask og alt det andre som også skal gjøres.
 
 Det er nettopp her mange små utleiere kjenner at det glipper. Ikke fordi de ikke vil gjøre ting riktig, men fordi manuelle løsninger er sårbare. En lapp på kjøkkenbordet blir borte. En SMS blir ikke fulgt opp. Gjestene drar tidlig på morgenen, og plutselig mangler du registrering for én av dagene, og du kan ikke avslutte og godkjenne fiskeperioden — som er grunnlaget for utførselsdokumentasjonen. Vi har selv stått i dette, og vi vet hvor fort en liten glipp blir til unødvendig stress.
 

--- a/src/content/blog/lovpalagt-fangstrapportering-fritidsboligeiere.md
+++ b/src/content/blog/lovpalagt-fangstrapportering-fritidsboligeiere.md
@@ -16,9 +16,9 @@ For hytteeiere og mindre utleiere som tilbyr båt og fiskeopplevelser til turist
 
 ## Hva betyr lovpålagt fangstrapportering for fritidsboligeiere?
 
-I praksis betyr det at du som leier ut fritidsbolig og båt [til turistfiskere](https://eksportfiske.no/registrer/), må ha kontroll på fangstdata når virksomheten omfattes av rapporteringsplikt. Det holder ikke å be turisten si fra ved avreise eller skrive noe på et ark. Opplysningene må samles inn riktig, til rett tid og på en måte som kan brukes videre i rapporteringen.
+I praksis betyr det at du som leier ut fritidsbolig og båt til turistfiskere, må ha kontroll på fangstdata når virksomheten [omfattes av rapporteringsplikt](/blogg/ma-du-registrere-turistfiskebedrift/). Det holder ikke å be turisten si fra ved avreise eller skrive noe på et ark. Opplysningene må samles inn riktig, til rett tid og på en måte som kan brukes videre i rapporteringen.
 
-Det er særlig kombinasjonen av overnatting, båtutleie og turistfiske som gjør dette relevant. Mange mindre aktører tenker fortsatt på seg selv som "bare en hytteeier". Men når du tar betalt for fiskeopplevelser, blir du i praksis en del av en [regulert verdikjede](https://eksportfiske.no/registrering/). Da holder det ikke med uformelle rutiner.
+Det er særlig kombinasjonen av overnatting, båtutleie og turistfiske som gjør dette relevant. Mange mindre aktører tenker fortsatt på seg selv som "bare en hytteeier". Men når du tar betalt for fiskeopplevelser, blir du i praksis en del av en regulert verdikjede. Da holder det ikke med uformelle rutiner.
 
 Mange blir overrasket over hvor mye ansvar som faktisk ligger hos utleier. Turisten registrerer fangsten, men du må ha et system som sikrer at det faktisk skjer — og at dokumentasjonen kan følges opp.
 
@@ -36,7 +36,7 @@ Selve rapporteringsplikten oppleves ofte som komplisert fordi mange blander fang
 
 Du må vite hvem som fisker, når de fisker, og hvilken fangst som tas opp — knyttet til riktig fiskeperiode. Hvis turisten senere skal ha dokumentasjon for utførsel av fisk, må grunnlaget allerede være korrekt. Feil i første ledd følger hele veien videre.
 
-Gode rutiner starter ved ankomst. Du bør ha en enkel måte for turisten å registrere daglig fangst på, og en prosess for å kontrollere at fiskeperioden er komplett før den avsluttes. Hvis du venter til avreisedagen, har du ventet for lenge.
+Gode rutiner starter ved ankomst. Du bør ha en enkel måte for turisten å [registrere daglig fangst](/blogg/daglig-fangstrapportering-turistfiske/) på, og en prosess for å kontrollere at fiskeperioden er komplett før den avsluttes. Hvis du venter til avreisedagen, har du ventet for lenge.
 
 ## Løs det daglig, ikke ved avreise
 
@@ -70,6 +70,12 @@ God rapportering er heller ikke bare et myndighetskrav. Turister som opplever at
 
 Hvis du driver utleie til turistfiskere, er det lite å vinne på å bygge egne nødløsninger rundt et regelverk som allerede er krevende. Du trenger et oppsett laget for denne typen drift — der fangstrapportering, kontroll og eksportdokumentasjon henger sammen.
 
-Det er akkurat det eksportfiske.no er bygget for. Du deler en lenke med turistene ved ankomst. De oppretter fiskeperioden og registrerer fangst dag for dag på sitt eget språk. Når de avslutter perioden, kontrollerer du og godkjenner — og rapporten går automatisk til Fiskeridirektoratet. Ingen dobbeltarbeid, ingen håndskrift å tolke etterpå.
+Det er akkurat det [eksportfiske.no](https://eksportfiske.no/registrer/ny-kunde/) er bygget for. Du deler en lenke med turistene ved ankomst. De oppretter fiskeperioden og registrerer fangst dag for dag på sitt eget språk. Når de avslutter perioden, kontrollerer du og godkjenner — og rapporten går automatisk til Fiskeridirektoratet. Ingen dobbeltarbeid, ingen håndskrift å tolke etterpå.
 
-For fritidsboligeiere som [leier ut til turistfiske](https://eksportfiske.no/registrer/ny-kunde/), er dette ikke lenger "greit å ha". Det er en del av grunnmuren. Jo tidligere du får rutinen på plass, desto mindre sårbar blir sesongen når tempoet øker.
+For fritidsboligeiere som leier ut til turistfiske, er dette ikke lenger "greit å ha". Det er en del av grunnmuren. Jo tidligere du får rutinen på plass, desto mindre sårbar blir sesongen når tempoet øker.
+
+## Kom i gang før sesongen
+
+Vi har bygget eksportfiske.no for fritidsboligeiere som vil ha rapporteringen på plass uten å investere i et stort system. Turistene registrerer fangsten på sitt eget språk via en unik e-postlenke, du godkjenner fiskeperioden før avreise, og utførselsdokumentasjonen ligger klar.
+
+[Registrer bedriften din i dag →](https://eksportfiske.no/registrer/ny-kunde/)

--- a/src/content/blog/ma-du-registrere-turistfiskebedrift.md
+++ b/src/content/blog/ma-du-registrere-turistfiskebedrift.md
@@ -28,7 +28,7 @@ For utleiere som har utenlandske gjester er frivillig registrering som regel det
 
 ## Det er ikke bare registreringen som avgjør
 
-Registrering er inngangen til flere plikter: daglig fangstrapportering til Fiskeridirektoratet, korrekt eksportdokumentasjon, og rutiner som faktisk fungerer i hverdagen. Det er her vi ser flest ryke uti — ikke på selve registreringen, men på oppfølgingen etterpå.
+Registrering er inngangen til flere plikter: [daglig fangstrapportering](/blogg/daglig-fangstrapportering-turistfiske/) til Fiskeridirektoratet, korrekt eksportdokumentasjon, og rutiner som faktisk fungerer i hverdagen. Det er her vi ser flest ryke uti — ikke på selve registreringen, men på oppfølgingen etterpå.
 
 Det holder med noen få gjester, flere språk og hektiske utsjekker før kontrollen glipper. Et papirskjema i resepsjonen, en SMS eller en muntlig bekreftelse fra gjesten er sjelden godt nok når rapporteringen skal være daglig og eksportdokumentasjonen må være korrekt.
 
@@ -42,7 +42,7 @@ Det avgjørende er ofte helheten i tilbudet. Hvis gjestene velger deg fordi de s
 
 ## Hvorfor kravene bare blir viktigere
 
-Dokumentasjonskravene i denne bransjen blir ikke mindre strenge. Fiskeridirektoratet forventer sporbarhet, daglig rapportering og at virksomheten har kontroll på hva som blir fanget og hva som blir tatt ut av landet.
+Dokumentasjonskravene i denne bransjen blir ikke mindre strenge. Fiskeridirektoratet forventer [sporbarhet og korrekt dokumentasjon](/blogg/lovpalagt-fangstrapportering-fritidsboligeiere/), daglig rapportering og at virksomheten har kontroll på hva som blir fanget og hva som blir tatt ut av landet.
 
 For utleiere betyr det at improviserte løsninger fungerer stadig dårligere. Det som gikk med få gjester og lav aktivitet, holder ikke når du først er innenfor ordningen. Da er spørsmålet om du må registrere turistfiskebedrift tett knyttet til om du har et system som faktisk tåler kontroll.
 
@@ -69,7 +69,7 @@ Start med å se ærlig på hva du tilbyr. Har du overnatting og båt? Kommer gje
 
 Se deretter på arbeidsflyten din. Hvordan samles fangstdata inn i dag? Hvem kontrollerer at opplysningene er riktige? Hvordan håndteres gjester som ikke snakker norsk? Og hva skjer når fem båter reiser samme dag? Hvis svarene er uklare, er det et driftssignal like mye som et regelverkssignal.
 
-Dette er nettopp behovet vi har bygget Eksportfiske.no for. Turistene registrerer fangst på eget språk via QR-kode, du godkjenner med ett klikk, og både den daglige rapporten til Fiskeridirektoratet og eksportdokumentet til gjesten går automatisk.
+Dette er nettopp behovet vi har bygget [eksportfiske.no](https://eksportfiske.no/registrer/ny-kunde/) for. Turistene registrerer fangst på eget språk via QR-kode, du godkjenner med ett klikk, og både den daglige rapporten til Fiskeridirektoratet og eksportdokumentet til gjesten går automatisk.
 
 ## Må du registrere turistfiskebedrift hvis du bare leier ut én hytte?
 
@@ -81,4 +81,4 @@ Det er innholdet i tjenesten som teller, ikke antall enheter.
 
 Hvis du sitter med spørsmålet _må jeg registrere turistfiskebedrift_, er du sannsynligvis nærmere grensen enn du tror. Det lønner seg å få avklaringen før sesongen starter, ikke når første gjest står i døren og spør om papirene for å ta med fangsten hjem.
 
-[Kom i gang gratis hos Eksportfiske.no](https://eksportfiske.no/registrer/ny-kunde/) — det tar under ti minutter å sette opp. Du får daglig fangstrapportering, eksportdokumenter på gjestenes språk, og en oppfølging som fungerer i praksis — ikke bare på papir.
+[Prøv eksportfiske.no gratis i én måned](https://eksportfiske.no/registrer/ny-kunde/) — det tar under ti minutter å sette opp. Du får daglig fangstrapportering, eksportdokumenter på gjestenes språk, og en oppfølging som fungerer i praksis — ikke bare på papir.


### PR DESCRIPTION
## Hva er endret

Tre bloggartikler er oppdatert med to mål: ryddigere CTA-lenker og et sammenhengende internt lenkenettverk (topic cluster).

### `daglig-fangstrapportering-turistfiske.md`
- La til crosslink på "for turistfiskebedrifter" i ingressen (linje 13) → peker til `ma-du-registrere-turistfiskebedrift`

### `lovpalagt-fangstrapportering-fritidsboligeiere.md`
- Fjernet to svakt plasserte lenker (linje 19 og 21) som pekte til eksportfiske.no med metaforiske ankertekster
- La til crosslink på "omfattes av rapporteringsplikt" (linje 19) → peker til `ma-du-registrere-turistfiskebedrift`
- La til crosslink på "registrere daglig fangst" (linje 39) → peker til `daglig-fangstrapportering-turistfiske`
- Lagt til brandlenke på "eksportfiske.no" (linje 73) med `/registrer/ny-kunde/`
- Fjernet svak CTA-lenke (linje 75)
- Ny avsluttende CTA-seksjon "Kom i gang før sesongen" med `/registrer/ny-kunde/`

### `ma-du-registrere-turistfiskebedrift.md`
- Brandlenke på "eksportfiske.no" (linje 72) med korrekt casing og `/registrer/ny-kunde/`
- Fikset misvisende "gratis"-påstand i CTA (linje 84): endret til "Prøv eksportfiske.no gratis i én måned" i tråd med 1 måneds prøveperiode som tilbys
- Crosslink på "daglig fangstrapportering" (linje 31) → peker til `daglig-fangstrapportering-turistfiske`
- Crosslink på "sporbarhet og korrekt dokumentasjon" (linje 45) → peker til `lovpalagt-fangstrapportering-fritidsboligeiere`

## Merknad om mulig konflikt

Denne PR-en og PR [fix/blog-boat-claim] berører begge `daglig-fangstrapportering-turistfiske.md`, men på ulike linjer — denne PR-en endrer kun linje 13 (ingressen), mens den andre PR-en har gjort endringer i siste del av filen. Konflikt er usannsynlig, men bør sjekkes ved sammenslåing.

## Byggvalidering

`npm run build` fullført uten feil — 13 sider bygget.