### PR TITLE
Endre registreringslenker i blogg fra /registrer/ny-kunde/ til /registrer/

### DIFF
--- a/src/content/blog/daglig-fangstrapportering-turistfiske.md
+++ b/src/content/blog/daglig-fangstrapportering-turistfiske.md
@@ -62,7 +62,7 @@ Mange som driver med [én hytte og én båt](https://eksportfiske.no/blogg/lovpa
 
 Når du driver alene eller sammen med familien, må systemet fungere uten opplæring, installasjon og teknisk styr. Det må være lett å sette i gang med, lett å bruke for gjestene og lett å kontrollere for deg. Det er også derfor lav terskel betyr så mye mer enn "fine funksjoner". Hvis løsningen ikke blir brukt hver dag, hjelper det lite hva den kan på papiret.
 
-Vi mener derfor at god daglig fangstrapportering turistfiske ikke først og fremst handler om avansert teknologi. Det handler om å fjerne friksjon. En løsning der turisten enkelt får tilgang via e-post og kan registrere på sitt eget språk er ofte mer verdifull enn et komplisert system med mange valg. Når det er enkelt, blir det gjort. Det er akkurat derfor [eksportfiske.no gjør rapporteringen enkel](https://eksportfiske.no/registrer/ny-kunde/) — turistene registrerer på eget språk via en e-postlenke, og du beholder kontrollen før utførselsdokumentasjonen utstedes.
+Vi mener derfor at god daglig fangstrapportering turistfiske ikke først og fremst handler om avansert teknologi. Det handler om å fjerne friksjon. En løsning der turisten enkelt får tilgang via e-post og kan registrere på sitt eget språk er ofte mer verdifull enn et komplisert system med mange valg. Når det er enkelt, blir det gjort. Det er akkurat derfor [eksportfiske.no gjør rapporteringen enkel](https://eksportfiske.no/registrer/) — turistene registrerer på eget språk via en e-postlenke, og du beholder kontrollen før utførselsdokumentasjonen utstedes.
 
 ## Hvordan gjøre oppstarten enkel for gjestene
 
@@ -86,4 +86,4 @@ For mange små utleiere er det nettopp det som teller mest. Ikke store ord, men 
 
 eksportfiske.no har vi laget for små utleiere som vil ha rutinen på plass uten å investere i et stort system. Turistene registrerer fangsten på sitt eget språk via en unik e-postlenke, du godkjenner fiskeperioden før avreise, og utførselsdokumentasjonen ligger klar.
 
-[Registrer bedriften din i dag →](https://eksportfiske.no/registrer/ny-kunde/)
+[Registrer bedriften din i dag →](https://eksportfiske.no/registrer/)

--- a/src/content/blog/lovpalagt-fangstrapportering-fritidsboligeiere.md
+++ b/src/content/blog/lovpalagt-fangstrapportering-fritidsboligeiere.md
@@ -70,7 +70,7 @@ God rapportering er heller ikke bare et myndighetskrav. Turister som opplever at
 
 Hvis du driver utleie til turistfiskere, er det lite å vinne på å bygge egne nødløsninger rundt et regelverk som allerede er krevende. Du trenger et oppsett laget for denne typen drift — der fangstrapportering, kontroll og eksportdokumentasjon henger sammen.
 
-Det er akkurat det [eksportfiske.no](https://eksportfiske.no/registrer/ny-kunde/) er bygget for. Du deler en lenke med turistene ved ankomst. De oppretter fiskeperioden og registrerer fangst dag for dag på sitt eget språk. Når de avslutter perioden, kontrollerer du og godkjenner — og rapporten går automatisk til Fiskeridirektoratet. Ingen dobbeltarbeid, ingen håndskrift å tolke etterpå.
+Det er akkurat det [eksportfiske.no](https://eksportfiske.no/registrer/) er bygget for. Du deler en lenke med turistene ved ankomst. De oppretter fiskeperioden og registrerer fangst dag for dag på sitt eget språk. Når de avslutter perioden, kontrollerer du og godkjenner — og rapporten går automatisk til Fiskeridirektoratet. Ingen dobbeltarbeid, ingen håndskrift å tolke etterpå.
 
 For fritidsboligeiere som leier ut til turistfiske, er dette ikke lenger "greit å ha". Det er en del av grunnmuren. Jo tidligere du får rutinen på plass, desto mindre sårbar blir sesongen når tempoet øker.
 
@@ -78,4 +78,4 @@ For fritidsboligeiere som leier ut til turistfiske, er dette ikke lenger "greit 
 
 Vi har bygget eksportfiske.no for fritidsboligeiere som vil ha rapporteringen på plass uten å investere i et stort system. Turistene registrerer fangsten på sitt eget språk via en unik e-postlenke, du godkjenner fiskeperioden før avreise, og utførselsdokumentasjonen ligger klar.
 
-[Registrer bedriften din i dag →](https://eksportfiske.no/registrer/ny-kunde/)
+[Registrer bedriften din i dag →](https://eksportfiske.no/registrer/)

--- a/src/content/blog/ma-du-registrere-turistfiskebedrift.md
+++ b/src/content/blog/ma-du-registrere-turistfiskebedrift.md
@@ -69,7 +69,7 @@ Start med å se ærlig på hva du tilbyr. Har du overnatting og båt? Kommer gje
 
 Se deretter på arbeidsflyten din. Hvordan samles fangstdata inn i dag? Hvem kontrollerer at opplysningene er riktige? Hvordan håndteres gjester som ikke snakker norsk? Og hva skjer når fem båter reiser samme dag? Hvis svarene er uklare, er det et driftssignal like mye som et regelverkssignal.
 
-Dette er nettopp behovet vi har bygget [eksportfiske.no](https://eksportfiske.no/registrer/ny-kunde/) for. Turistene registrerer fangst på eget språk via QR-kode, du godkjenner med ett klikk, og både den daglige rapporten til Fiskeridirektoratet og eksportdokumentet til gjesten går automatisk.
+Dette er nettopp behovet vi har bygget [eksportfiske.no](https://eksportfiske.no/registrer/) for. Turistene registrerer fangst på eget språk via QR-kode, du godkjenner med ett klikk, og både den daglige rapporten til Fiskeridirektoratet og eksportdokumentet til gjesten går automatisk.
 
 ## Må du registrere turistfiskebedrift hvis du bare leier ut én hytte?
 
@@ -81,4 +81,4 @@ Det er innholdet i tjenesten som teller, ikke antall enheter.
 
 Hvis du sitter med spørsmålet _må jeg registrere turistfiskebedrift_, er du sannsynligvis nærmere grensen enn du tror. Det lønner seg å få avklaringen før sesongen starter, ikke når første gjest står i døren og spør om papirene for å ta med fangsten hjem.
 
-[Prøv eksportfiske.no gratis i én måned](https://eksportfiske.no/registrer/ny-kunde/) — det tar under ti minutter å sette opp. Du får daglig fangstrapportering, eksportdokumenter på gjestenes språk, og en oppfølging som fungerer i praksis — ikke bare på papir.
+[Prøv eksportfiske.no gratis i én måned](https://eksportfiske.no/registrer/) — det tar under ti minutter å sette opp. Du får daglig fangstrapportering, eksportdokumenter på gjestenes språk, og en oppfølging som fungerer i praksis — ikke bare på papir.


### PR DESCRIPTION
## Summary

Forenkler alle registreringslenker i bloggartiklene fra `/registrer/ny-kunde/` til `/registrer/`.

6 lenker endret på tvers av tre artikler:
- `daglig-fangstrapportering-turistfiske.md` — 2 lenker (in-body + closing CTA)
- `lovpalagt-fangstrapportering-fritidsboligeiere.md` — 2 lenker (in-body + closing CTA)
- `ma-du-registrere-turistfiskebedrift.md` — 2 lenker (in-body + closing CTA)

## Test plan

- [x] `npm run build` lokalt bygger alle 13 sider uten feil
- [ ] Sjekk at /registrer/ fortsatt rendrer riktig etter deploy

## Merk

Checklisten i `.github/workflows/soro-rss-sync.yml:67` refererer fortsatt til `/registrer/ny-kunde/` som kanonisk CTA. Den bør eventuelt oppdateres separat hvis fremtidige Soro-artikler også skal peke til `/registrer/`.