### PR TITLE
Retningslinjer for bloggartikkel-gjennomgang + kanonisk /registrer/-lenke

### DIFF
--- a/.github/workflows/soro-rss-sync.yml
+++ b/.github/workflows/soro-rss-sync.yml
@@ -64,7 +64,7 @@ jobs:
             - [ ] Stemmen er konsistent med eksportfiske.no (første person, norsk)
             - [ ] Tre-delt registreringstest (MVA + 50 000 kr + båt) er korrekt fremstilt
             - [ ] Datoer og årstall er korrekte (ingen udokumenterte "fra 2025"-påstander)
-            - [ ] CTA peker til /registrer/ny-kunde/ og er tydelig
+            - [ ] CTA peker til /registrer/ og er tydelig
             - [ ] Interne lenker er gyldige
             - [ ] Artikkelen er klar for publisering
           commit-message: "Legg til artikler fra Soro RSS"

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -14,7 +14,7 @@ const legalCollection = defineCollection({
 // Note: the frontmatter `slug` field is consumed by the glob loader as entry.id
 // and must not be declared in the schema.
 const blogCollection = defineCollection({
-  loader: glob({ pattern: '**/*.md', base: './src/content/blog' }),
+  loader: glob({ pattern: ['**/*.md', '!REVIEW_GUIDELINES.md'], base: './src/content/blog' }),
   schema: ({ image }) =>
     z.object({
       title: z.string(),

--- a/src/content/blog/REVIEW_GUIDELINES.md
+++ b/src/content/blog/REVIEW_GUIDELINES.md
@@ -64,9 +64,11 @@ Påstander som "over halvparten av gjestene er tyskspråklige" er ikke verifiser
 - Ikke fest lenker på tangentiale ord ("regulert verdikjede" → registreringsside gir ingen mening).
 - Enten bruk et naturlig verb/uttrykk, eller la ordet stå som ren tekst og plasser CTA-en et annet sted.
 
-### Avsluttende CTA-seksjon
+### Ikke legg til egen CTA-seksjon i artikler
 
-Hver artikkel bør avsluttes med en dedikert `## Kom i gang...`-seksjon med tydelig handlingslenke. Brand-omtaler i brødteksten kan også lenkes, men den avsluttende CTA-en er konverteringsankeret.
+Bloggmalen (`src/pages/blogg/[...slug].astro`) rendrer automatisk en "Klar til å komme i gang?"-seksjon med knapper til `/registrer/` og `/registrering` på alle bloggsider. Egne `## Kom i gang...`-seksjoner i artikkelen blir derfor dobbel CTA — ikke legg dem til.
+
+Brand-omtaler i brødteksten kan fortsatt lenkes der det flyter naturlig (f.eks. "det er akkurat det [eksportfiske.no](https://eksportfiske.no/registrer/) er bygget for"). Det er den avsluttende malsseksjonen som er konverteringsankeret.
 
 ## Redaksjonell konsistens
 

--- a/src/content/blog/REVIEW_GUIDELINES.md
+++ b/src/content/blog/REVIEW_GUIDELINES.md
@@ -1,0 +1,80 @@
+# Retningslinjer for bloggartikkel-gjennomgang
+
+Dette dokumentet er en sjekkliste for å gjennomgå bloggartikler i `src/content/blog/`, spesielt artikler importert automatisk fra Soro via `.github/workflows/soro-rss-sync.yml`. Bruk listen før artikler merges til master.
+
+> **Merk:** Dette er et arbeidsdokument, ikke en publisert artikkel. Filen er ekskludert fra bloggens content collection via glob-mønster i `src/content.config.ts`.
+
+## Faktasjekk mot produkt og regelverk
+
+### Per-båt-rapportering er feil
+
+Fiskeridirektoratet sin API (swagger: `turistfiskeapi-test.fiskeridir.no/swagger/v1/swagger.json`) har ingen felt for båt/fartøy. Rapporteringen er strukturert slik:
+
+```
+Company → Camp (hytte) → CompanyStay (opphold) → Trip → Catch
+```
+
+- Bruk "per opphold" eller "per fiskeperiode", ikke "per båt" eller "per fartøy".
+- FAQ-en på `src/pages/index.astro:800` bekrefter: all fangst rapporteres samlet for virksomheten, uavhengig av båt eller hytte.
+- Båt-referanser som farge ("flere båter ute samtidig" som illustrasjon på manuelt kaos) er greit — det er kun konkrete påstander om at rapportering må knyttes til bestemt båt som er feil.
+
+### Utførselsdokumentasjon er ikke daglig gated
+
+- Utførselsdokumentasjon utstedes når utleier godkjenner hele fiskeperioden etter at gjesten har avsluttet den.
+- Daglig rapportering er påkrevd av regelverket, men det er periode-lukking + godkjenning som utløser dokumentet.
+- Ikke skriv som om hver enkelt dagsrapport direkte låser opp utførselsdokumentet.
+
+### Gjestens tilgangsflyt
+
+Faktisk flyt:
+1. Utleier deler subdomene-lenke eller QR-kode (se `/qr`)
+2. Turisten oppretter fiskeperiode og oppgir e-post
+3. Turisten får unik lenke til dashbord via e-post
+4. Turisten registrerer fangst via dashbordet
+
+- Ikke beskriv som ren "åpne en lenke" uten e-post-steget.
+- "Passordløs lenke" er upresist.
+
+### Regelverksdatoer krever kilde
+
+- Daglig rapporteringsplikt stammer fra forskrift 2017-07-05-1141 (2017).
+- Påstander som "Fra 1. august 2025..." krever dokumentert kilde, ellers reformuler til "Regelverket krever..." uten datoanker.
+- Soro-sjekklisten i `.github/workflows/soro-rss-sync.yml:67` flagger dette eksplisitt.
+
+### Generelle statistikker må dempes eller tilskrives
+
+Påstander som "over halvparten av gjestene er tyskspråklige" er ikke verifiserbare på tvers av alle utleiere. Bruk "en stor andel" eller knytt til spesifikk aktør.
+
+## CTA og URL-konvensjoner
+
+### Kanonisk registreringsadresse
+
+**`https://eksportfiske.no/registrer/`** er kanonisk URL for CTA-er i bloggartikler og på bloggsider.
+
+- Både Soro-sjekklisten (`.github/workflows/soro-rss-sync.yml`) og blog-templaten (`src/pages/blogg/[...slug].astro`) skal peke til `/registrer/`.
+- `/registrer/ny-kunde/` brukes ikke — bruk alltid `/registrer/`.
+
+### "Gratis" er misvisende alene
+
+- Produktet har én måned gratis prøveperiode (`src/pages/index.astro:725`), ikke permanent gratis.
+- Skriv "gratis prøveperiode" eller "gratis i én måned", aldri bare "gratis".
+
+### Ankertekst må matche destinasjonen
+
+- Ikke fest lenker på tangentiale ord ("regulert verdikjede" → registreringsside gir ingen mening).
+- Enten bruk et naturlig verb/uttrykk, eller la ordet stå som ren tekst og plasser CTA-en et annet sted.
+
+### Avsluttende CTA-seksjon
+
+Hver artikkel bør avsluttes med en dedikert `## Kom i gang...`-seksjon med tydelig handlingslenke. Brand-omtaler i brødteksten kan også lenkes, men den avsluttende CTA-en er konverteringsankeret.
+
+## Redaksjonell konsistens
+
+- **Varenavn:** Bruk alltid `eksportfiske.no` med liten e. Ikke `Eksportfiske.no`.
+- **Stemme:** Første person, kollektiv ("Vi har selv stått i dette", "Vi mener"). Skribent håndhever denne stilen.
+- **Kryssreferanser:** De tre eksisterende artiklene bør referere til hverandre på naturlige tematiske punkter. Bruk interne stier (`/blogg/<slug>/`), ikke absolutte URL-er.
+
+## Gjennomgangsprosess
+
+- Soro RSS-importer kommer som PR-er med en sjekkliste i PR-body (se `.github/workflows/soro-rss-sync.yml:61-69`). Verifiser hver avkrysningsboks før merge.
+- Delegér innholdsgjennomgang til Skribent, build-validering til DeployBot, SEO til Søk. Skipper koordinerer.

--- a/src/content/blog/daglig-fangstrapportering-turistfiske.md
+++ b/src/content/blog/daglig-fangstrapportering-turistfiske.md
@@ -81,9 +81,3 @@ Et annet tydelig tegn er at du har begynt å få flere korte opphold. Jo oftere 
 Vi nevner ikke dette for å dramatisere. Tvert imot. Poenget er at du kan ta grep før det blir et problem. Når rapporteringen går digitalt og løpende, får du en enklere hverdag og bedre kontroll uten å bruke mer tid.
 
 For mange små utleiere er det nettopp det som teller mest. Ikke store ord, men en løsning som gjør at dagen flyter. Du vet at kravene følges. Gjestene forstår hva de skal gjøre. Og når de skal reise hjem, ligger grunnlaget klart i stedet for å være noe du må jage inn i siste liten.
-
-## Kom i gang med enkel daglig rapportering
-
-eksportfiske.no har vi laget for små utleiere som vil ha rutinen på plass uten å investere i et stort system. Turistene registrerer fangsten på sitt eget språk via en unik e-postlenke, du godkjenner fiskeperioden før avreise, og utførselsdokumentasjonen ligger klar.
-
-[Registrer bedriften din i dag →](https://eksportfiske.no/registrer/)

--- a/src/content/blog/lovpalagt-fangstrapportering-fritidsboligeiere.md
+++ b/src/content/blog/lovpalagt-fangstrapportering-fritidsboligeiere.md
@@ -73,9 +73,3 @@ Hvis du driver utleie til turistfiskere, er det lite å vinne på å bygge egne 
 Det er akkurat det [eksportfiske.no](https://eksportfiske.no/registrer/) er bygget for. Du deler en lenke med turistene ved ankomst. De oppretter fiskeperioden og registrerer fangst dag for dag på sitt eget språk. Når de avslutter perioden, kontrollerer du og godkjenner — og rapporten går automatisk til Fiskeridirektoratet. Ingen dobbeltarbeid, ingen håndskrift å tolke etterpå.
 
 For fritidsboligeiere som leier ut til turistfiske, er dette ikke lenger "greit å ha". Det er en del av grunnmuren. Jo tidligere du får rutinen på plass, desto mindre sårbar blir sesongen når tempoet øker.
-
-## Kom i gang før sesongen
-
-Vi har bygget eksportfiske.no for fritidsboligeiere som vil ha rapporteringen på plass uten å investere i et stort system. Turistene registrerer fangsten på sitt eget språk via en unik e-postlenke, du godkjenner fiskeperioden før avreise, og utførselsdokumentasjonen ligger klar.
-
-[Registrer bedriften din i dag →](https://eksportfiske.no/registrer/)

--- a/src/content/blog/ma-du-registrere-turistfiskebedrift.md
+++ b/src/content/blog/ma-du-registrere-turistfiskebedrift.md
@@ -77,8 +77,4 @@ Ofte er dette spørsmålet stilt med håp om et enkelt nei. Men én hytte er ikk
 
 Det er innholdet i tjenesten som teller, ikke antall enheter.
 
-## Kom i gang før sesongen
-
 Hvis du sitter med spørsmålet _må jeg registrere turistfiskebedrift_, er du sannsynligvis nærmere grensen enn du tror. Det lønner seg å få avklaringen før sesongen starter, ikke når første gjest står i døren og spør om papirene for å ta med fangsten hjem.
-
-[Prøv eksportfiske.no gratis i én måned](https://eksportfiske.no/registrer/) — det tar under ti minutter å sette opp. Du får daglig fangstrapportering, eksportdokumenter på gjestenes språk, og en oppfølging som fungerer i praksis — ikke bare på papir.

--- a/src/pages/blogg/[...slug].astro
+++ b/src/pages/blogg/[...slug].astro
@@ -110,7 +110,7 @@ const jsonLd = {
       </p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
         <a
-          href="/registrer/ny-kunde/"
+          href="/registrer/"
           class="bg-primary hover:bg-primary-hover text-white font-semibold px-8 py-4 rounded-lg transition-colors text-center shadow-md hover:shadow-lg"
         >
           Kom i gang gratis


### PR DESCRIPTION
## Summary

Legger til `src/content/blog/REVIEW_GUIDELINES.md` som samler faktasjekk, CTA-regler og redaksjonelle konvensjoner for gjennomgang av bloggartikler (særlig Soro RSS-importer). Dokumentet er ekskludert fra Astro content collection via glob-mønster i `src/content.config.ts`.

Samtidig rettes gjenværende `/registrer/ny-kunde/`-referanser sitewide til kanonisk `/registrer/`:
- `src/pages/blogg/[...slug].astro:113` — CTA-knapp på alle bloggsider
- `.github/workflows/soro-rss-sync.yml:67` — sjekkliste-oppføring i PR-body for Soro-importer

## Endringer

- **Ny fil:** `src/content/blog/REVIEW_GUIDELINES.md` — retningslinjer i norsk, bruk ved gjennomgang
- **`src/content.config.ts`** — blog glob utvidet med `!REVIEW_GUIDELINES.md` for å unngå schema-feil
- **`src/pages/blogg/[...slug].astro`** — CTA-knapp peker nå til `/registrer/`
- **`.github/workflows/soro-rss-sync.yml`** — sjekkliste-tekst oppdatert til `/registrer/`

## Merk

Blogartiklenes egne lenker fikses i parallell PR #196. Den åpne PR-en har overlappende formål (samme URL-endring), men i artikkelfilene. Dette PR-et tar resten.

Button-teksten "Kom i gang gratis" i `blogg/[...slug].astro:116` er også misvisende per de nye retningslinjene (produktet har 1 måned gratis prøveperiode, ikke permanent gratis). Ikke endret i dette PR-et — bør tas i en separat runde.

## Test plan

- [x] `npm run build` lokalt bygger alle 13 sider uten feil (REVIEW_GUIDELINES.md er ekskludert)
- [ ] Verifiser at CTA-knapp på bloggsider peker til `/registrer/` etter deploy
- [ ] Neste Soro-import bruker oppdatert sjekkliste