### PR TITLE
FAQ: Gruppe-registrering, per-person eksportdokument og lenkedeling

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -803,6 +803,57 @@ import logo from '../assets/logo.png';
           </div>
         </details>
 
+        <!-- FAQ 9.5 - Group registration -->
+        <details class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden group">
+          <summary class="cursor-pointer px-6 py-5 font-semibold text-lg text-gray-900 hover:bg-gray-50 transition-colors list-none flex justify-between items-center">
+            <span>Må hver gjest i en gruppe registrere fangst selv, eller kan én person gjøre det for alle?</span>
+            <svg class="w-5 h-5 text-gray-500 transition-transform group-open:rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+            </svg>
+          </summary>
+          <div class="px-6 py-4 text-gray-600 border-t border-gray-100">
+            <p>
+              En person i gruppen — gjerne lagleder — kan registrere fangst for hele fiskelaget, og det er faktisk den vanligste bruken.
+              Vedkommende oppretter fiskeperioder for hver fisker og fører fangst fortløpende.
+              Tilgangen til dashbordet kan også deles videre hvis flere skal kunne registrere.
+            </p>
+          </div>
+        </details>
+
+        <!-- FAQ 9.6 - Per-person export docs -->
+        <details class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden group">
+          <summary class="cursor-pointer px-6 py-5 font-semibold text-lg text-gray-900 hover:bg-gray-50 transition-colors list-none flex justify-between items-center">
+            <span>Blir det ett eksportdokument per person eller ett felles for gruppen?</span>
+            <svg class="w-5 h-5 text-gray-500 transition-transform group-open:rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+            </svg>
+          </summary>
+          <div class="px-6 py-4 text-gray-600 border-t border-gray-100">
+            <p>
+              Ett per person. Utførselskvoten er personlig — 15 kg inntil to ganger i året (2026-kvoten) — og dokumentasjonen
+              må derfor utstedes individuelt. Den som registrerer for gruppen mottar alle dokumentene samlet etter at
+              fiskeperioden er avsluttet og godkjent, og kan distribuere dem videre til hver fisker.
+            </p>
+          </div>
+        </details>
+
+        <!-- FAQ 9.7 - Distributing the link -->
+        <details class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden group">
+          <summary class="cursor-pointer px-6 py-5 font-semibold text-lg text-gray-900 hover:bg-gray-50 transition-colors list-none flex justify-between items-center">
+            <span>Hvordan deler jeg lenken med gjestene?</span>
+            <svg class="w-5 h-5 text-gray-500 transition-transform group-open:rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+            </svg>
+          </summary>
+          <div class="px-6 py-4 text-gray-600 border-t border-gray-100">
+            <p>
+              Du får en egen subdomeneadresse (for eksempel <code class="bg-gray-100 px-1.5 py-0.5 rounded text-sm">ditt-firma.export.fish</code>)
+              som du kan dele på tre måter: i velkomstmail eller SMS, som QR-kode i hyttemappa, eller direkte til
+              en lagleder som distribuerer videre til gruppen. Gjestene oppretter sin egen fiskeperiode fra den samme lenken.
+            </p>
+          </div>
+        </details>
+
         <!-- FAQ 10 -->
         <details class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden group">
           <summary class="cursor-pointer px-6 py-5 font-semibold text-lg text-gray-900 hover:bg-gray-50 transition-colors list-none flex justify-between items-center">


### PR DESCRIPTION
## Summary

Legger til tre nye FAQ-oppføringer basert på spørsmål fra Solstrand Fjord Holiday. Dette er problemstillinger som ikke dekkes i eksisterende FAQ-er, men som kom frem som reelle behov hos en utleier:

1. **Må hver gjest i en gruppe registrere fangst selv, eller kan én person gjøre det for alle?** — Nei, lagleder kan gjøre alt. Dette er den vanligste bruken.
2. **Blir det ett eksportdokument per person eller ett felles for gruppen?** — Ett per person fordi kvoten (15 kg × 2/år) er personlig. Lagleder mottar alle samlet for distribusjon.
3. **Hvordan deler jeg lenken med gjestene?** — Subdomene-adresse (`ditt-firma.export.fish`) delt via e-post/SMS, QR-kode eller direkte til lagleder.

Plassert mellom FAQ om "flere båter/hytter" og "tekniske problemer" slik at operasjonelle spørsmål ligger samlet.

## Test plan

- [x] `npm run build` lokalt bygger alle 13 sider uten feil
- [ ] Verifiser at `<details>`-elementene åpner/lukker korrekt på siden