### PR TITLE
Naturlig norsk i tittel og overskrift på aldersgrense-artikkel

### DIFF
--- a/src/content/blog/aldersgrense-turistfiske-12-ar.md
+++ b/src/content/blog/aldersgrense-turistfiske-12-ar.md
@@ -1,6 +1,6 @@
 ---
-title: "Aldersgrense turistfiske 12 år - hva gjelder?"
-description: "Lurer du på aldersgrense turistfiske 12 år? Her får du en praktisk forklaring på hva som gjelder for barn, rapportering og utførsel."
+title: "Aldersgrense i turistfiske: hva gjelder for 12-åringer?"
+description: "Lurer du på hva aldersgrensen betyr i turistfiske? Her får du en praktisk forklaring på hva som gjelder for barn på 12 år, rapportering og utførsel."
 slug: "aldersgrense-turistfiske-12-ar"
 guid: "ac241f34-2165-4e8d-abde-605a5b2f6866"
 pubDate: 2026-04-25T06:06:19.000Z
@@ -10,11 +10,11 @@ image:
 tags: []
 ---
 
-Spørsmålet om aldersgrense turistfiske 12 år dukker gjerne opp rett før familien skal reise hjem: kan barnet stå oppført på utførselsdokumentasjonen sammen med de voksne, eller gjelder det andre regler? For deg som leier ut hytte og båt er dette ikke bare et småspørsmål. Det påvirker hvordan du informerer gjestene, og hvordan du unngår misforståelser i det øyeblikket familien spør deg om svar.
+Spørsmålet om aldersgrense i turistfiske dukker gjerne opp rett før familien skal reise hjem: kan barnet stå oppført på utførselsdokumentasjonen sammen med de voksne, eller gjelder det andre regler? For deg som leier ut hytte og båt er dette ikke bare et småspørsmål. Det påvirker hvordan du informerer gjestene, og hvordan du unngår misforståelser i det øyeblikket familien spør deg om svar.
 
 Det som gjør spørsmålet vanskelig er at mange blander tre ulike ting: hvem som kan delta i fisket, hvem som kan oppføres ved utførsel, og hvordan fangsten skal rapporteres i løpet av oppholdet. Når disse tre tingene flyter sammen, oppstår det fort usikkerhet, særlig når gjesten spør om en 12-åring "teller med".
 
-## Aldersgrense turistfiske 12 år — hva spørsmålet egentlig handler om
+## Hva aldersgrensen på 12 år i turistfiske egentlig handler om
 
 Mange leter etter ett klart tall som løser alt. Problemet er at regelverket sjelden fungerer slik. Om barnet er med på båten og deltar i fisket er én del av bildet. Om familien ønsker utførselsdokumentasjon er en annen del. Og når fangsten skal rapporteres daglig per opphold og art, slik [regelverket krever](/blogg/daglig-fangstrapportering-turistfiske/), må opplysningene inn på en korrekt måte uansett hvem som deltok.
 


### PR DESCRIPTION
## Summary

Fortsettelse av språkforbedringen i `aldersgrense-turistfiske-12-ar.md`. PR #205 ble merget før den siste språkfiksen rakk å lande, så endringene tas her i en egen PR.

Søkeord-formen "aldersgrense turistfiske 12 år" (uten preposisjon) leste som en søkesyntaks, ikke norsk prosa. Nå er den naturlig med preposisjon "i" og variasjon på tvers av plasseringene.

## Endringer

| Plassering | Før | Etter |
|---|---|---|
| Tittel | "Aldersgrense turistfiske 12 år - hva gjelder?" | "Aldersgrense i turistfiske: hva gjelder for 12-åringer?" |
| Description | "Lurer du på aldersgrense turistfiske 12 år? Her..." | "Lurer du på hva aldersgrensen betyr i turistfiske? Her... barn på 12 år..." |
| Innledning | "Spørsmålet om aldersgrense turistfiske 12 år dukker..." | "Spørsmålet om aldersgrense i turistfiske dukker..." |
| H2-overskrift | "Aldersgrense turistfiske 12 år — hva spørsmålet egentlig handler om" | "Hva aldersgrensen på 12 år i turistfiske egentlig handler om" |

Slug, image, kryssreferanser og artikkelens kropp er uendret.

## Test plan

- [x] `npm run build` — alle 16 sider bygger uten feil