### PR TITLE
Hero word swap: minimum interval 1s

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1088,10 +1088,10 @@ import logo from '../assets/logo.png';
   (function () {
     const words = ['hytta', 'båten'];
 
-    // 10 intervals, exponential-ish decay from 500ms → 2500ms.
+    // 8 intervals, exponential-ish decay from 1000ms → ~2660ms (1.15× per step).
     // Total animation time ≈ sum of intervals + transition overhead ≈ 15s.
     const intervals = [
-      500, 600, 720, 870, 1050, 1260, 1500, 1800, 2150, 2500
+      1000, 1150, 1320, 1520, 1750, 2010, 2310, 2660
     ];
 
     const motionOk = !window.matchMedia('(prefers-reduced-motion: reduce)').matches;


### PR DESCRIPTION
## Summary
Bumps the fastest interval in the hero "hytta"↔"båten" word swap from 500ms to 1000ms — 500ms felt too snappy. Reworks the table to 8 steps with a 1.15× growth ratio so the total runtime stays around 15s.

New intervals (ms): `[1000, 1150, 1320, 1520, 1750, 2010, 2310, 2660]`

This branch contains the cumulative work from #206 (animation + monospace font + random settle) plus this timing tweak. Suggest closing #206 in favour of this PR.

## Test plan
- [ ] `npm run dev` — confirm headline starts swapping at 1s and decelerates
- [ ] Total runtime feels right (~15s) before settling
- [ ] Settle word still randomises between "hytta" and "båten" across refreshes
- [ ] `prefers-reduced-motion` still suppresses animation