### PR TITLE
Legg til KI-disclosure nederst i blogginnlegg

### DIFF
--- a/src/pages/blogg/[...slug].astro
+++ b/src/pages/blogg/[...slug].astro
@@ -96,6 +96,11 @@ const jsonLd = {
       <div class="article-body text-gray-800 leading-relaxed">
         <Content />
       </div>
+
+      <!-- Editorial disclosure -->
+      <footer class="mt-12 pt-6 border-t border-gray-200 text-sm text-gray-500">
+        Skrevet med hjelp av KI.
+      </footer>
     </div>
   </article>
 


### PR DESCRIPTION
## Sammendrag
Legger til en kort, diskret linje nederst i alle blogginnlegg (over CTA-seksjonen) som signaliserer at innholdet er KI-assistert:

> Skrevet med hjelp av KI.

Stilen er liten grå tekst med en tynn topp-border, plassert inni samme `max-w-2xl`-container som artikkelteksten.

## Bakgrunn
- Bidrar til transparens (EU AI Act, Google E-E-A-T-signaler)
- "KI" er den korrekte norske forkortelsen (kunstig intelligens), ikke "AI"
- Per-artikkel-plassering valgt fordi siden ikke har en delt footer-komponent ennå

## Test-plan
- [ ] `npm run dev` — åpne et blogginnlegg, se at linja vises mellom artikkeltekst og CTA
- [ ] Sjekk at den ikke forstyrrer lesingen visuelt
- [ ] Sjekk på mobil at marginene ser riktige ut