### PR TITLE
Differensier artikkel 6 fra artikkel 2: fritidsboligeier-vinkling

### DIFF
--- a/src/content/blog/lovpalagt-fangstrapportering-fritidsboligeiere.md
+++ b/src/content/blog/lovpalagt-fangstrapportering-fritidsboligeiere.md
@@ -28,7 +28,7 @@ For en profesjonell turistfiskebedrift med fast ansatte og daglig drift er det m
 
 Tenk på situasjonen: du leier ut hytta via Airbnb, gjestene ankommer en fredag kveld når du ikke er til stede, og de fisker fra lørdag med robåten som ligger ved brygga. De er en blanding av tyske og nederlandske turister, ingen snakker norsk, og ingen av dem visste at det fantes noe som het fangstrapportering. Et papirskjema på kjøkkenbenken — på norsk — løser ingenting her.
 
-Situasjonen er enda mer krevende med motorbåt inkludert i leien, fordi gjestene da kan fiske langt fra hytta og lande fangsten et annet sted. Du mister sporbarhet uten å ha gjort noe galt. Og selv om du følger opp med SMS etterpå, husker gjestene sjelden nøyaktig art eller vekt to dager etter at fisken ble tatt opp.
+Selv om du følger opp med SMS etterpå, husker gjestene sjelden nøyaktig art eller vekt to dager etter at fisken ble tatt opp. Du mister sporbarhet uten å ha gjort noe galt — fangst forfaller raskt i hukommelsen, og det blir bare verre jo lenger tid det går før noen registrerer den.
 
 Det manuelle systemet forutsetter at noen er til stede, at gjestene forstår hva de skal gjøre, og at de gjør det. For de fleste fritidsboligeiere stemmer ingen av disse forutsetningene.
 
@@ -54,8 +54,7 @@ Det som faktisk fungerer er at gjestene selv håndterer sin del — men med tyde
 
 Her er forskjellen mellom ulike oppsett:
 - **Hytte uten båt**: Gjestene fisker fra land eller tar med egen båt. Rapporteringsplikten gjelder fortsatt hvis du er registrert, men din rolle er enklere.
-- **Hytte med robåt**: Gjestene fisker nær hytta. Oversikten er håndterbar, og daglig registrering er realistisk.
-- **Hytte med motorbåt**: Gjestene kan fiske lenger unna og lander fangst ulike steder. Løpende digital registrering er eneste praktiske måte å holde oversikt.
+- **Hytte med båt (robåt eller motorbåt)**: Daglig digital registrering er den eneste rutinen som faktisk holder gjennom en sesong. Båttype betyr lite for kravet — det er antall gjester, hyppigheten av bytter og dine egne arbeidstider som avgjør hvor avhengig du er av at gjestene rapporterer selv.
 - **Airbnb med fiske som ekstra tilbud**: Mange gjester forventer ikke fiskebyråkrati når de booker. Tydelig forhåndsinformasjon og et enkelt verktøy er det som avgjør om det faktisk skjer.
 
 Felles for alle: du trenger en rutine som ikke forutsetter at du er til stede. Det er den eneste modellen som tåler fri-uke, full booking og gjester som reiser tidlig mandag morgen.

--- a/src/content/blog/lovpalagt-fangstrapportering-fritidsboligeiere.md
+++ b/src/content/blog/lovpalagt-fangstrapportering-fritidsboligeiere.md
@@ -16,19 +16,21 @@ For hytteeiere og mindre utleiere som tilbyr båt og fiskeopplevelser til turist
 
 ## Hva betyr lovpålagt fangstrapportering for fritidsboligeiere?
 
-I praksis betyr det at du som leier ut fritidsbolig og båt til turistfiskere, må ha kontroll på fangstdata når virksomheten [omfattes av rapporteringsplikt](/blogg/ma-du-registrere-turistfiskebedrift/). Det holder ikke å be turisten si fra ved avreise eller skrive noe på et ark. Opplysningene må samles inn riktig, til rett tid og på en måte som kan brukes videre i rapporteringen.
+I praksis betyr det at du som leier ut fritidsbolig og båt til turistfiskere, må ha kontroll på fangstdata når virksomheten [omfattes av rapporteringsplikt](/blogg/ma-du-registrere-turistfiskebedrift/). Plikten inntrer når du er MVA-registrert, over 50 000 kr i bruttoinntekt og har båt — mange fritidsboligeiere ligger under denne grensen, men velger frivillig registrering fordi det gir gjestene utførselskvote. Det holder ikke å be turisten si fra ved avreise eller skrive noe på et ark. Opplysningene må samles inn riktig, til rett tid og på en måte som kan brukes videre i rapporteringen.
 
 Det er særlig kombinasjonen av overnatting, båtutleie og turistfiske som gjør dette relevant. Mange mindre aktører tenker fortsatt på seg selv som "bare en hytteeier". Men når du tar betalt for fiskeopplevelser, blir du i praksis en del av en regulert verdikjede. Da holder det ikke med uformelle rutiner.
 
 Mange blir overrasket over hvor mye ansvar som faktisk ligger hos utleier. Turisten registrerer fangsten, men du må ha et system som sikrer at det faktisk skjer — og at dokumentasjonen kan følges opp.
 
-## Hvorfor manuelle rutiner ofte svikter
+## Hvorfor manuelle rutiner svikter for fritidsboligeiere
 
-Papirlister, SMS og notater ved avreise kan fungere når du har få turister og full oversikt. Problemet oppstår når sesongen blir travel, turistene kommer fra flere land, og fisket skjer over flere dager med ulike båter og personer. Da øker feilmarginen raskt.
+For en profesjonell turistfiskebedrift med fast ansatte og daglig drift er det mulig å bygge manuelle rutiner som faktisk holder. For en fritidsboligeier er det mye vanskeligere — og det er en viktig forskjell.
 
-Vi har selv stått i dette, og vi vet hva som glipper når rapporteringen blir noe man "tar på slutten av uka". Turistene husker ikke nøyaktig art eller vekt, ansatte tolker notater forskjellig, og avreisedagen er for hektisk til å rydde opp i mangler. Resultatet er merarbeid og svakere etterlevelse.
+Tenk på situasjonen: du leier ut hytta via Airbnb, gjestene ankommer en fredag kveld når du ikke er til stede, og de fisker fra lørdag med robåten som ligger ved brygga. De er en blanding av tyske og nederlandske turister, ingen snakker norsk, og ingen av dem visste at det fantes noe som het fangstrapportering. Et papirskjema på kjøkkenbenken — på norsk — løser ingenting her.
 
-Manuell håndtering skaper også et ansvarsfall: sitter turisten på manglende registrering, sitter du med problemet. Du trenger rutiner som fungerer mens fiskeperioden pågår, ikke bare etter den er over.
+Situasjonen er enda mer krevende med motorbåt inkludert i leien, fordi gjestene da kan fiske langt fra hytta og lande fangsten et annet sted. Du mister sporbarhet uten å ha gjort noe galt. Og selv om du følger opp med SMS etterpå, husker gjestene sjelden nøyaktig art eller vekt to dager etter at fisken ble tatt opp.
+
+Det manuelle systemet forutsetter at noen er til stede, at gjestene forstår hva de skal gjøre, og at de gjør det. For de fleste fritidsboligeiere stemmer ingen av disse forutsetningene.
 
 ## Hva må du ha kontroll på i praksis?
 
@@ -44,13 +46,19 @@ Det mest praktiske grepet er å tenke daglig flyt i stedet for sluttrapport. Tur
 
 I praksis er forskjellen på et system som brukes og et som ikke brukes: enkelhet. Hvis registreringen oppleves som tung, hopper folk over den. Da hjelper det lite at rutinen finnes.
 
-## Slik lager du en trygg arbeidsflyt
+## Slik fungerer en trygg arbeidsflyt for deg som ikke er der
 
-En god arbeidsflyt trenger ikke være komplisert. Den må bare være konsekvent. Ved ankomst forklarer du kort at turisten selv oppretter fiskeperioden og registrerer fangst [hver dag, også dager uten fisk](/blogg/nullfangst-turistfiske-ma-det-rapporteres/). Underveis kan du følge med og ta tak i avvik. Når turisten avslutter fiskeperioden ved avreise, kontrollerer du og godkjenner — da er grunnlaget klart for rapportering og eksportdokumentasjon.
+Den største utfordringen for fritidsboligeiere er ikke vilje til å følge reglene — det er at hverdagen ikke er satt opp for det. Du er kanskje ikke til stede når gjestene ankommer. Du har ikke et resepsjonssystem. Du har ikke ansatte som kan svare på spørsmål om fiskeperioder og eksportdokumentasjon.
 
-Det er midtfasen mange undervurderer. Uten løpende registrering sitter du med hukommelse og manuell oppsamling i høysesong. Det er sjelden en trygg modell.
+Det som faktisk fungerer er at gjestene selv håndterer sin del — men med tydelig instruksjon og et verktøy de faktisk forstår. I praksis betyr det: du sender en lenke og en kort forklaring på engelsk (eller tysk) før ankomst. Gjestene oppretter fiskeperioden selv og registrerer fangst [hver dag, også dager uten fisk](/blogg/nullfangst-turistfiske-ma-det-rapporteres/). Du kan følge med eksternt og ta tak i avvik uten å måtte dra til hytta.
 
-Prinsippet er det samme uansett størrelse: rapporteringsarbeidet må være løpende, dokumenterbart og lett å kontrollere.
+Her er forskjellen mellom ulike oppsett:
+- **Hytte uten båt**: Gjestene fisker fra land eller tar med egen båt. Rapporteringsplikten gjelder fortsatt hvis du er registrert, men din rolle er enklere.
+- **Hytte med robåt**: Gjestene fisker nær hytta. Oversikten er håndterbar, og daglig registrering er realistisk.
+- **Hytte med motorbåt**: Gjestene kan fiske lenger unna og lander fangst ulike steder. Løpende digital registrering er eneste praktiske måte å holde oversikt.
+- **Airbnb med fiske som ekstra tilbud**: Mange gjester forventer ikke fiskebyråkrati når de booker. Tydelig forhåndsinformasjon og et enkelt verktøy er det som avgjør om det faktisk skjer.
+
+Felles for alle: du trenger en rutine som ikke forutsetter at du er til stede. Det er den eneste modellen som tåler fri-uke, full booking og gjester som reiser tidlig mandag morgen.
 
 ## Når regelverk møter gjesteopplevelse
 


### PR DESCRIPTION
## Hva er endret

Artikkel 6 (`lovpalagt-fangstrapportering-fritidsboligeiere.md`) er omskrevet for å tydelig differensiere seg fra artikkel 2 (`ma-du-registrere-turistfiskebedrift.md`).

**Problem:** To seksjoner i artikkel 6 leste som generelle registreringsargumenter identiske med artikkel 2, og ikke som innhold rettet mot fritidsboligeierens spesifikke situasjon.

## Endrede seksjoner

**"Hvorfor manuelle rutiner svikter for fritidsboligeiere"** (overskrift justert)
- Erstattet generell industriomtale med et konkret Airbnb-scenario: gjester ankommer fredag kveld uten at eier er til stede, tyske og nederlandske turister uten norskkunnskaper, papirskjema på kjøkkenbenken fungerer ikke
- Motorbåt-scenarioet brukt for å forklare sporbarhetstap
- Avsluttet med å eksplisittere at manuelt system forutsetter tilstedeværelse, språkforståelse og gjesteinnsats — forutsetninger som sjelden stemmer for fritidsboligeiere

**"Slik fungerer en trygg arbeidsflyt for deg som ikke er der"** (overskrift omskrevet)
- Erstattet generisk ankomst-/midtfase-/avreisemal med konkret beskrivelse av hva som faktisk fungerer når eieren ikke er til stede
- Lagt til fire konkrete oppsett som punktliste: hytte uten båt, hytte med robåt, hytte med motorbåt, Airbnb med fiske som side-tilbud

## 50 000 kr-presisering

Lagt inn i "Hva betyr lovpålagt fangstrapportering for fritidsboligeiere?" — én setning som klargjør MVA-grensen og at mange fritidsboligeiere er under terskelen men velger frivillig registrering. Lenken til artikkel 2 er beholdt.

## SEO-konsekvenser

Differensieringen er SEO-positiv: artikkel 6 treffer nå unike long-tail-termer (Airbnb fiske utleie, fritidsbolig robåt, hytteutleie uten fast ansatte) og konkurrerer ikke lenger med artikkel 2 på generelle registreringsuttrykk. Frontmatter er ikke endret i denne omgangen — description-optimalisering anbefales som separat oppgave.

## Build-status

Build passerte uten feil. 17 sider bygget.