### PR TITLE
Legg til forfatter-felt på blogginnlegg

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -21,6 +21,7 @@ const blogCollection = defineCollection({
       description: z.string(),
       guid: z.string(),
       pubDate: z.coerce.date(),
+      author: z.string().default('Kim Eik'),
       image: z
         .object({
           src: image(),

--- a/src/content/blog/aldersgrense-turistfiske-12-ar.md
+++ b/src/content/blog/aldersgrense-turistfiske-12-ar.md
@@ -4,6 +4,7 @@ description: "Lurer du på hva aldersgrensen betyr i turistfiske? Her får du en
 slug: "aldersgrense-turistfiske-12-ar"
 guid: "ac241f34-2165-4e8d-abde-605a5b2f6866"
 pubDate: 2026-04-25T06:06:19.000Z
+author: "Kim Eik"
 image:
   src: "./images/aldersgrense-turistfiske-12-ar.webp"
   alt: "Aldersgrense turistfiske 12 år - hva gjelder?"

--- a/src/content/blog/bot-for-turistfiske-rapportering.md
+++ b/src/content/blog/bot-for-turistfiske-rapportering.md
@@ -4,6 +4,7 @@ description: "Hva kan bot for turistfiske-rapportering bety i praksis? Se hva re
 slug: "bot-for-turistfiske-rapportering"
 guid: "22c9610b-7455-4ee5-ba96-9ac874c112cd"
 pubDate: 2026-04-26T06:12:19.000Z
+author: "Kim Eik"
 image:
   src: "./images/bot-for-turistfiske-rapportering.webp"
   alt: "Bot for turistfiske-rapportering?"

--- a/src/content/blog/daglig-fangstrapportering-turistfiske.md
+++ b/src/content/blog/daglig-fangstrapportering-turistfiske.md
@@ -4,6 +4,7 @@ description: "Regelverket krever daglig fangstrapportering i turistfiske. Slik g
 slug: "daglig-fangstrapportering-turistfiske"
 guid: "8dc94a43-733f-492c-84da-31661f4f9559"
 pubDate: 2026-04-22T19:50:39.000Z
+author: "Kim Eik"
 image:
   src: "./images/daglig-fangstrapportering-turistfiske.webp"
   alt: "Daglig fangstrapportering i turistfiske"

--- a/src/content/blog/lovpalagt-fangstrapportering-fritidsboligeiere.md
+++ b/src/content/blog/lovpalagt-fangstrapportering-fritidsboligeiere.md
@@ -4,6 +4,7 @@ description: "Lovpålagt fangstrapportering for fritidsboligeiere krever gode ru
 slug: "lovpalagt-fangstrapportering-fritidsboligeiere"
 guid: "3429a3e7-2335-4d5d-9d2b-ee2cb4832f27"
 pubDate: 2026-04-21T11:17:55.000Z
+author: "Kim Eik"
 image:
   src: "./images/lovpalagt-fangstrapportering-fritidsboligeiere.webp"
   alt: "Lovpålagt fangstrapportering for fritidsboligeiere"

--- a/src/content/blog/ma-du-registrere-turistfiskebedrift.md
+++ b/src/content/blog/ma-du-registrere-turistfiskebedrift.md
@@ -4,6 +4,7 @@ description: "Må du registrere turistfiskebedrift? Få klar oversikt over regle
 slug: "ma-du-registrere-turistfiskebedrift"
 guid: "a4381f64-11f4-475b-8170-2da75d0ded64"
 pubDate: 2026-04-21T08:37:06.000Z
+author: "Kim Eik"
 image:
   src: "./images/ma-du-registrere-turistfiskebedrift.webp"
   alt: "Må du registrere turistfiskebedrift?"

--- a/src/content/blog/nullfangst-turistfiske-ma-det-rapporteres.md
+++ b/src/content/blog/nullfangst-turistfiske-ma-det-rapporteres.md
@@ -4,6 +4,7 @@ description: "Nullfangst skaper ofte usikkerhet i turistfiskedriften. Her får d
 slug: "nullfangst-turistfiske-ma-det-rapporteres"
 guid: "a21b343d-7a06-47d8-800e-4846f9f0af88"
 pubDate: 2026-04-23T05:51:21.000Z
+author: "Kim Eik"
 image:
   src: "./images/nullfangst-turistfiske-ma-det-rapporteres.webp"
   alt: "Nullfangst turistfiske - må det rapporteres?"

--- a/src/content/blog/slik-kan-du-forberede-turistfiskesesongen.md
+++ b/src/content/blog/slik-kan-du-forberede-turistfiskesesongen.md
@@ -4,6 +4,7 @@ description: "Slik kan du forberede turistfiskesesongen med riktige rutiner for 
 slug: "slik-kan-du-forberede-turistfiskesesongen"
 guid: "1bcc9f68-f054-4b2f-a758-31475c12317e"
 pubDate: 2026-04-24T05:54:33.000Z
+author: "Kim Eik"
 image:
   src: "./images/slik-kan-du-forberede-turistfiskesesongen.webp"
   alt: "Slik kan du forberede turistfiskesesongen"

--- a/src/pages/blogg/[...slug].astro
+++ b/src/pages/blogg/[...slug].astro
@@ -32,6 +32,10 @@ const jsonLd = {
   description: entry.data.description,
   datePublished: entry.data.pubDate.toISOString(),
   url: canonicalURL,
+  author: {
+    '@type': 'Person',
+    name: entry.data.author,
+  },
   publisher: {
     '@type': 'Organization',
     name: 'Eksportfiske.no',


### PR DESCRIPTION
## Sammendrag
Legger til `author`-felt i bloggens content schema og setter `Kim Eik` som forfatter på alle syv eksisterende artikler. Forfatteren eksponeres i JSON-LD strukturert data (`Person`-type) for E-E-A-T-signalering, men vises foreløpig ikke som synlig byline (KI-disclosure-linja nederst dekker transparensbehovet).

## Endringer
- `src/content.config.ts`: nytt `author`-felt med standardverdi `"Kim Eik"` — eksisterende automatiserte Soro-artikler får standardverdien automatisk hvis de ikke spesifiserer forfatter
- Alle syv blogginnlegg: eksplisitt `author: "Kim Eik"` i frontmatter (selv om standardverdien dekker, gjør det attribusjonen synlig på fil-nivå)
- `src/pages/blogg/[...slug].astro`: JSON-LD inkluderer nå `author: { @type: "Person", name: ... }`

## Test-plan
- [ ] `npm run build` — passerer (verifisert lokalt, 17 sider)
- [ ] Inspiser JSON-LD på et blogginnlegg — `author`-feltet skal være med
- [ ] Sjekk visuelt at ingenting er endret i artikkellayouten (forfatteren er kun i metadata)