### PR TITLE
Korriger bøtehjemmel og 12-årsgrense med juridiske kilder

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -21,6 +21,7 @@ const blogCollection = defineCollection({
       description: z.string(),
       guid: z.string(),
       pubDate: z.coerce.date(),
+      author: z.string().default('Kim Eik'),
       image: z
         .object({
           src: image(),

--- a/src/content/blog/aldersgrense-turistfiske-12-ar.md
+++ b/src/content/blog/aldersgrense-turistfiske-12-ar.md
@@ -4,6 +4,7 @@ description: "Lurer du på hva aldersgrensen betyr i turistfiske? Her får du en
 slug: "aldersgrense-turistfiske-12-ar"
 guid: "ac241f34-2165-4e8d-abde-605a5b2f6866"
 pubDate: 2026-04-25T06:06:19.000Z
+author: "Kim Eik"
 image:
   src: "./images/aldersgrense-turistfiske-12-ar.webp"
   alt: "Aldersgrense turistfiske 12 år - hva gjelder?"

--- a/src/content/blog/aldersgrense-turistfiske-12-ar.md
+++ b/src/content/blog/aldersgrense-turistfiske-12-ar.md
@@ -13,24 +13,44 @@ tags: []
 
 Spørsmålet om aldersgrense i turistfiske dukker gjerne opp rett før familien skal reise hjem: kan barnet stå oppført på utførselsdokumentasjonen sammen med de voksne, eller gjelder det andre regler? For deg som leier ut hytte og båt er dette ikke bare et småspørsmål. Det påvirker hvordan du informerer gjestene, og hvordan du unngår misforståelser i det øyeblikket familien spør deg om svar.
 
-Det som gjør spørsmålet vanskelig er at mange blander tre ulike ting: hvem som kan delta i fisket, hvem som kan oppføres ved utførsel, og hvordan fangsten skal rapporteres i løpet av oppholdet. Når disse tre tingene flyter sammen, oppstår det fort usikkerhet, særlig når gjesten spør om en 12-åring "teller med".
+## Det direkte svaret: hva 12-årsgrensen faktisk regulerer
 
-## Hva aldersgrensen på 12 år i turistfiske egentlig handler om
+Fra 1. august 2025 gjelder en aldersgrense på 12 år for å bruke **utførselskvoten** for turistfisk. Dette er fastsatt i § 2 i forskrift om utførselsregulering av fisk og fiskevarer fra sportsfiske (FOR-2006-06-01-570), som nå lyder: "Den som fører ut fisk eller fiskevarer må være fylt 12 år."
 
-Mange leter etter ett klart tall som løser alt. Problemet er at regelverket sjelden fungerer slik. Om barnet er med på båten og deltar i fisket er én del av bildet. Om familien ønsker utførselsdokumentasjon er en annen del. Og når fangsten skal rapporteres daglig per opphold og art, slik [regelverket krever](/blogg/daglig-fangstrapportering-turistfiske/), må opplysningene inn på en korrekt måte uansett hvem som deltok.
+Grensen handler utelukkende om hvem som kan stå som person på utførselskvoten — altså hvem som kan ta fisk med ut av landet. Den regulerer **ikke** retten til å delta i fisket. Et barn på 10 år kan fullt lovlig fiske fra båten, og fangsten kan inngå i familiens totale fangst. Men barnet kan ikke selv stå som kvoteperson ved utreise — det kan bare personer som har fylt 12 år.
 
-Det tryggeste er å unngå bastante husregler som "under 12 år teller ikke" hvis du ikke vet nøyaktig hva du legger i det. Informer gjestene tidlig, ikke kvelden før avreise. Fortell at all fangst under oppholdet må håndteres korrekt gjennom [fangstrapportering](/blogg/lovpalagt-fangstrapportering-fritidsboligeiere/), og at utførselsdokumentasjon forutsetter at rapportene er i orden. Da settes spørsmålet om barnets alder inn i riktig sammenheng.
+## Et konkret eksempel: familie med to barn
 
-## Rapportering og ansvar — der ansvaret faktisk sitter
+En familie med to voksne og to barn (10 og 13 år) besøker en registrert turistfiskebedrift. Slik fordeler reglene seg:
 
-Selv om spørsmålet stilles som et aldersspørsmål, er ansvaret ditt som utleier mer knyttet til rapporteringen enn til hvem som holdt fiskestangen. Det sentrale er at fangsten blir registrert riktig per opphold og art, og at grunnlaget for utførselsdokumentasjon er på plass. Det forutsetter at virksomheten din er [registrert som turistfiskebedrift](/blogg/ma-du-registrere-turistfiskebedrift/), for uten registrering har gjestene ingen utførselskvote i det hele tatt.
+- **Alle fire** kan delta i fisket fra båten — det er ingen aldersgrense for selve fiskeaktiviteten
+- **Tre av fire** kan bruke utførselskvoten ved avreise: de to voksne og 13-åringen
+- **10-åringen** kan ikke stå oppført som kvoteperson — fangsten som er fanget av eller tilskrives barnet, må fordeles på de andre
 
-Når dette glipper, hjelper det lite å vite nøyaktig om barnet var 11 eller 12 år. Feil oppstår som regel i flyten rundt dataene, ikke i alderen til den som fisket.
+For deg som utleier betyr dette at du bør informere gjester med barn tidlig i oppholdet: hvem er 12 år eller eldre, og hvem kan stå på utførselsdokumentasjonen? Det er en enkel avklaring som sparer stress ved utsjekk.
+
+## Rapportering og hvem som "teller"
+
+At 10-åringen ikke kan bruke utførselskvoten, betyr ikke at fangsten forsvinner. All fangst under oppholdet skal [rapporteres daglig](/blogg/daglig-fangstrapportering-turistfiske/) per opphold og art, uavhengig av hvem som holdt fiskestangen. Det er den samlede fangsten per opphold som rapporteres — ikke fordelt på individuelle fiskere.
+
+Utfordringen er at kvoten beregnes per person ved utreise. Hvis familien ønsker å ta med 60 kg fisk hjem, og bare tre av fire kan bruke kvoten, setter det en reell grense for hva de faktisk kan eksportere. Det er et praktisk spørsmål som gjestene bør tenke på i god tid — ikke kvelden før avreise.
+
+## Ansvaret ditt som utleier
+
+Ditt ansvar er å ha dokumentasjonen i orden: korrekt fangstrapportering gjennom oppholdet og gyldig eksportdokumentasjon ved avreise. Eksportdokumentet skal inneholde navn, fødselsdato og adresse for hver person som bruker kvoten — og da er det avgjørende at alle oppgitte personer faktisk er 12 år eller eldre.
+
+Forutsatt at [virksomheten er registrert som turistfiskebedrift](/blogg/ma-du-registrere-turistfiskebedrift/) og rapporteringen er på plass, er selve alderskontrollen håndterbar: be gjestene oppgi hvem i familien som er over 12 år ved innsjekk, og registrer dette som del av oppholdsopplysningene. Da slipper du overraskelser i siste liten.
 
 ## Praktisk opplegg for utleiere
 
-Ved utreise kan situasjonen bli konkret raskt. To barn har vært med på båten hele uken, familien spør om begge kan regnes med på dokumentasjonen, og de forventer svar med en gang. Her bør du ikke improvisere. Knytt svaret til at utførselsdokumentasjon bygger på korrekt registrerte opplysninger fra hele oppholdet. Er det tvil, avklar mot gjeldende veiledning fra myndighetene fremfor å lage din egen praksis.
+En kort avklaring tidlig i oppholdet hjelper mye: hvem deltar i fisket, hvem er 12 år eller eldre, og forventer de å ta med fisk hjem? Husk at [dager uten fangst](/blogg/nullfangst-turistfiske-ma-det-rapporteres/) også inngår i rapporteringen — hull i datagrunnlaget er like problematisk som feil aldersregistrering.
 
-For å komme dit uten stress trenger du en rutine som tåler at gjestene bytter båtfører underveis og stiller spørsmål på tysk eller engelsk. En kort avklaring tidlig i oppholdet hjelper mye: hvem deltar i fisket, hvem disponerer båten, og forventer de å ta med fisk hjem? Den samtalen sparer mye fram og tilbake. Husk at [dager uten fangst](/blogg/nullfangst-turistfiske-ma-det-rapporteres/) også inngår i rapporteringen, og at hull i datagrunnlaget er like problematisk som feil registrering.
+Når rapporteringen går daglig og strukturert, og aldersopplysningene er registrert fra start, er spørsmål om barn ved utsjekk en enkel sak — ikke en situasjon der du må improvisere svar på gjestens tysk eller engelsk.
 
-Når rapporteringen går daglig og strukturert, blir spørsmål om barn langt enklere å håndtere. Du trenger ikke ett riktig svar på aldersgrensen. Du trenger et opplegg som gjør det enkelt å gjøre rett.
+---
+
+## Kilder
+
+- [Forskrift om utførselsregulering av fisk og fiskevarer fra sportsfiske § 2 (FOR-2006-06-01-570)](https://lovdata.no/dokument/SF/forskrift/2006-06-01-570) — aldersgrense 12 år for utførselskvote, ikraft 1. august 2025 (jf. endringsforskrift FOR-2025-07-01-1395)
+- [Fiskeridirektoratet: Fiskesmugling og utførsel](https://www.fiskeridir.no/turistfiske/fiskesmugling-og-utfoersel) — om utførselskvoten og alderskrav
+- [Forskrift om turistfiskevirksomheter (FOR-2017-07-05-1141)](https://lovdata.no/dokument/SF/forskrift/2017-07-05-1141) — rapporteringsplikt og dokumentasjonskrav

--- a/src/content/blog/bot-for-turistfiske-rapportering.md
+++ b/src/content/blog/bot-for-turistfiske-rapportering.md
@@ -4,6 +4,7 @@ description: "Hva kan bot for turistfiske-rapportering bety i praksis? Se hva re
 slug: "bot-for-turistfiske-rapportering"
 guid: "22c9610b-7455-4ee5-ba96-9ac874c112cd"
 pubDate: 2026-04-26T06:12:19.000Z
+author: "Kim Eik"
 image:
   src: "./images/bot-for-turistfiske-rapportering.webp"
   alt: "Bot for turistfiske-rapportering?"

--- a/src/content/blog/daglig-fangstrapportering-turistfiske.md
+++ b/src/content/blog/daglig-fangstrapportering-turistfiske.md
@@ -4,6 +4,7 @@ description: "Regelverket krever daglig fangstrapportering i turistfiske. Slik g
 slug: "daglig-fangstrapportering-turistfiske"
 guid: "8dc94a43-733f-492c-84da-31661f4f9559"
 pubDate: 2026-04-22T19:50:39.000Z
+author: "Kim Eik"
 image:
   src: "./images/daglig-fangstrapportering-turistfiske.webp"
   alt: "Daglig fangstrapportering i turistfiske"

--- a/src/content/blog/lovpalagt-fangstrapportering-fritidsboligeiere.md
+++ b/src/content/blog/lovpalagt-fangstrapportering-fritidsboligeiere.md
@@ -4,6 +4,7 @@ description: "Lovpålagt fangstrapportering for fritidsboligeiere krever gode ru
 slug: "lovpalagt-fangstrapportering-fritidsboligeiere"
 guid: "3429a3e7-2335-4d5d-9d2b-ee2cb4832f27"
 pubDate: 2026-04-21T11:17:55.000Z
+author: "Kim Eik"
 image:
   src: "./images/lovpalagt-fangstrapportering-fritidsboligeiere.webp"
   alt: "Lovpålagt fangstrapportering for fritidsboligeiere"

--- a/src/content/blog/ma-du-registrere-turistfiskebedrift.md
+++ b/src/content/blog/ma-du-registrere-turistfiskebedrift.md
@@ -4,6 +4,7 @@ description: "Må du registrere turistfiskebedrift? Få klar oversikt over regle
 slug: "ma-du-registrere-turistfiskebedrift"
 guid: "a4381f64-11f4-475b-8170-2da75d0ded64"
 pubDate: 2026-04-21T08:37:06.000Z
+author: "Kim Eik"
 image:
   src: "./images/ma-du-registrere-turistfiskebedrift.webp"
   alt: "Må du registrere turistfiskebedrift?"

--- a/src/content/blog/ma-du-registrere-turistfiskebedrift.md
+++ b/src/content/blog/ma-du-registrere-turistfiskebedrift.md
@@ -60,9 +60,11 @@ Hvis flere av disse stemmer, er du som regel innenfor — enten pliktig (hvis du
 
 ## Hva det koster å la være
 
-Den største risikoen er ikke bare en formell feil. Uten registrering har gjestene dine null utførselskvote. Tas de i kontroll med fisk uten dokumentasjon, risikerer de **8 000 kr i grunnbot, 200 kr per overskuddskilo, og beslag av hele fangsten**. Det er ikke en bot du sender en turist hjem med etter å ha betalt dyrt for opphold, båt og reise. Men selv registrerte virksomheter kan havne i trøbbel — [manglende eller feil rapportering](/blogg/bot-for-turistfiske-rapportering/) er en like vanlig kilde til problem som manglende registrering.
+Den største risikoen er ikke bare en formell feil. Uten registrering har gjestene dine null utførselskvote. Er de uregistrerte og forsøker å ta med fisk ut av Norge, regnes det som fiskesmugling — og Tolletaten kan beslaglegge hele fangsten og anmelde forholdet til politiet. Riksadvokatens bøtesatser for ulovlig utførsel er **8 000 kr i grunnbøte og 200 kr per kilo over tillatt mengde**. Det er ikke en bot du sender en turist hjem med etter å ha betalt dyrt for opphold, båt og reise.
 
-For deg som utleier betyr manglende registrering at gjestene ikke kan eksportere fisk i det hele tatt — et tydelig konkurransehemmer mot naboer som er registrert. Legg til risikoen for dårlige anmeldelser, tapte bookinger og eventuelle overtredelsesgebyrer fra Fiskeridirektoratet, og regnestykket blir ganske entydig.
+For deg som registrert virksomhet er sanksjonsbildet et annet: brudd på rapporteringsplikten etter turistfiskeforskriften §§ 2–5 kan medføre **overtredelsesgebyr opp til 100 000 kr** (jf. forskrift 2011-12-20-1437 § 5). Gjentatte eller grove brudd kan i tillegg føre til **sletting fra Fiskeridirektoratets register** (turistfiskeforskriften § 6) — noe som i praksis stenger virksomheten ute fra ordningen. [Manglende eller feil rapportering](/blogg/bot-for-turistfiske-rapportering/) er like vanlig kilde til problem som manglende registrering.
+
+For deg som utleier betyr manglende registrering at gjestene ikke kan eksportere fisk i det hele tatt — et tydelig konkurransehemmer mot naboer som er registrert. Legg til risikoen for dårlige anmeldelser, tapte bookinger og eventuelle gebyrer, og regnestykket blir ganske entydig.
 
 ## Slik vurderer du din egen drift
 
@@ -79,3 +81,12 @@ Ofte er dette spørsmålet stilt med håp om et enkelt nei. Men én hytte er ikk
 Det er innholdet i tjenesten som teller, ikke antall enheter.
 
 Hvis du sitter med spørsmålet _må jeg registrere turistfiskebedrift_, er du sannsynligvis nærmere grensen enn du tror. Det lønner seg å få avklaringen før sesongen starter, ikke når første gjest står i døren og spør om papirene for å ta med fangsten hjem.
+
+---
+
+## Kilder
+
+- [Forskrift om turistfiskevirksomheter (FOR-2017-07-05-1141)](https://lovdata.no/dokument/SF/forskrift/2017-07-05-1141) — registreringsplikt (§ 1), rapporteringsplikt (§§ 2–4), sletting fra register (§ 6), overtredelsesgebyr (§ 8)
+- [Forskrift om overtredelsesgebyr mv. etter havressursloven (FOR-2011-12-20-1437)](https://lovdata.no/dokument/SF/forskrift/2011-12-20-1437) — satser for overtredelsesgebyr, opp til 100 000 kr
+- [Fiskeridirektoratet: Fiskesmugling og utførsel](https://www.fiskeridir.no/turistfiske/fiskesmugling-og-utfoersel) — bøtesatser ved ulovlig utførsel (8 000 kr grunnbøte + 200 kr/kg), fastsatt av Riksadvokaten
+- [Forskrift om utførselsregulering av fisk og fiskevarer fra sportsfiske (FOR-2006-06-01-570)](https://lovdata.no/dokument/SF/forskrift/2006-06-01-570) — utførselskvote og vilkår for registrerte turistfiskebedrifter

--- a/src/content/blog/nullfangst-turistfiske-ma-det-rapporteres.md
+++ b/src/content/blog/nullfangst-turistfiske-ma-det-rapporteres.md
@@ -4,6 +4,7 @@ description: "Nullfangst skaper ofte usikkerhet i turistfiskedriften. Her får d
 slug: "nullfangst-turistfiske-ma-det-rapporteres"
 guid: "a21b343d-7a06-47d8-800e-4846f9f0af88"
 pubDate: 2026-04-23T05:51:21.000Z
+author: "Kim Eik"
 image:
   src: "./images/nullfangst-turistfiske-ma-det-rapporteres.webp"
   alt: "Nullfangst turistfiske - må det rapporteres?"

--- a/src/content/blog/slik-kan-du-forberede-turistfiskesesongen.md
+++ b/src/content/blog/slik-kan-du-forberede-turistfiskesesongen.md
@@ -4,6 +4,7 @@ description: "Slik kan du forberede turistfiskesesongen med riktige rutiner for 
 slug: "slik-kan-du-forberede-turistfiskesesongen"
 guid: "1bcc9f68-f054-4b2f-a758-31475c12317e"
 pubDate: 2026-04-24T05:54:33.000Z
+author: "Kim Eik"
 image:
   src: "./images/slik-kan-du-forberede-turistfiskesesongen.webp"
   alt: "Slik kan du forberede turistfiskesesongen"

--- a/src/pages/blogg/[...slug].astro
+++ b/src/pages/blogg/[...slug].astro
@@ -32,6 +32,10 @@ const jsonLd = {
   description: entry.data.description,
   datePublished: entry.data.pubDate.toISOString(),
   url: canonicalURL,
+  author: {
+    '@type': 'Person',
+    name: entry.data.author,
+  },
   publisher: {
     '@type': 'Organization',
     name: 'Eksportfiske.no',


### PR DESCRIPTION
## Hva er endret

### Artikkel 2: Registrering av turistfiskebedrift
Bøtesatsen 8 000 kr + 200 kr/kg var plassert i feil kontekst — den gjelder fiskesmugling/utførsel over kvote (Riksadvokatens bøtedirektiv, kontrollert av Tolletaten), ikke brudd på rapporteringsplikten. Artikkelen skiller nå tydelig mellom to separate sanksjonsregimer:

- **Gjester:** 8 000 kr grunnbøte + 200 kr/kg for ulovlig utførsel over kvote (fiskesmugling)
- **Registrert virksomhet:** Overtredelsesgebyr opp til 100 000 kr (FOR-2011-12-20-1437 § 5) og sletting fra register (FOR-2017-07-05-1141 § 6) ved brudd på rapporteringsplikt

Kildeseksjon lagt til med Lovdata-lenker.

### Artikkel 3: Aldersgrense i turistfiske
Artikkelen ble fullstendig omskrevet — tittelen lovet svar som den opprinnelige teksten ikke ga.

- Gir nå det direkte svaret: 12-årsgrensen (ikraft 1. august 2025, FOR-2006-06-01-570 § 2) gjelder **utfoerselsretten**, ikke fisketillatelsen
- Konkret familieeksempel (barn 10 og 13 år) som viser hvem som kan bruke kvoten
- Praktisk veiledning for utleiere om aldersavklaring ved innsjekk
- Kildeseksjon med Lovdata-lenker og endringsforskrift FOR-2025-07-01-1395

## Research-grunnlag
Verifisert mot Lovdata, Fiskeridirektoratets nettsider og NHO Reiseliv. Ingen påstander som ikke er bekreftet av offisielle kilder.

## Bygg
npm run build fullforte uten feil — 17 sider generert.