### PR TITLE
Delingsknapper og retningslinjer for heltebilder på blogg

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -14,7 +14,7 @@ const legalCollection = defineCollection({
 // Note: the frontmatter `slug` field is consumed by the glob loader as entry.id
 // and must not be declared in the schema.
 const blogCollection = defineCollection({
-  loader: glob({ pattern: ['**/*.md', '!REVIEW_GUIDELINES.md'], base: './src/content/blog' }),
+  loader: glob({ pattern: ['**/*.md', '!REVIEW_GUIDELINES.md', '!HERO_IMAGE_GUIDELINES.md'], base: './src/content/blog' }),
   schema: ({ image }) =>
     z.object({
       title: z.string(),

--- a/src/content/blog/HERO_IMAGE_GUIDELINES.md
+++ b/src/content/blog/HERO_IMAGE_GUIDELINES.md
@@ -1,0 +1,225 @@
+# Hero Image Guidelines — eksportfiske.no
+
+> This document defines the visual language for all blog hero images on eksportfiske.no.
+> It is designed as a **nano-banana prompt prefix** — paste the "Common Theme Prefix" section
+> verbatim at the start of every image generation prompt, then append the per-article
+> scene description.
+
+---
+
+## Brand Context
+
+**Site**: eksportfiske.no — marketing for a PWA reporting app for Norwegian fishing tourism operators (turistfiskebedrifter).
+
+**Audience**: Small Norwegian coastal business owners who rent out cabins and boats to foreign fishing tourists. They are practical, no-nonsense, and deeply connected to the Norwegian coast.
+
+**Tone**: Professional, trustworthy, authentically Norwegian coastal. Not stock-photo touristy, not glamour fishing, not holiday-brochure. Think: a real working harbour at 7am, not a glossy magazine spread.
+
+---
+
+## Common Theme Prefix
+
+> **Copy this verbatim as the opening of every nano-banana generation prompt.**
+
+```
+Photorealistic wide-format hero image for a Norwegian coastal fishing tourism website.
+Norwegian coastal palette: deep fjord navy (#1a3a5c), weathered granite grey,
+fjord teal (#4a9b8e), pale morning sky, and soft natural daylight — no saturated
+or tropical colours. Setting is authentically Norwegian: fjords, rocky coastline,
+weathered wooden docks, traditional red or ochre boathouses (naust), calm open
+water, overcast or soft golden Nordic light.
+
+Compositional rules:
+- Wide landscape format (3:2), subject centred or rule-of-thirds
+- No text, no logos, no signs, no watermarks anywhere in the image
+- No people's faces — backs, hands, silhouettes permitted if atmospheric
+- No smartphones, tablets, computers, or screens visible
+- No stock-photo clichés (no posed thumbs-up, no fake smiles, no bright tropical water)
+- Foreground interest with mid-ground subject and atmospheric background depth
+- Colour grade: slightly desaturated, cool-to-neutral, cinematic — not Instagram-filtered
+- Mood: calm, purposeful, early morning or overcast Nordic light
+- Photography style: documentary/editorial, as if shot by a Norwegian nature photographer
+
+The image must work as a 1536×1024 px hero image (3:2 aspect ratio).
+Keep the centre-left third of the image relatively uncluttered (text placement zone).
+```
+
+---
+
+## What to Avoid (Hard Rules)
+
+- No text, numbers, signs, labels, or watermarks anywhere
+- No company logos or app icons
+- No people's faces (backs and hands are fine)
+- No screens or devices
+- No tropical, Mediterranean, or non-Norwegian scenery
+- No oversaturated "golden hour Instagram" colour grading
+- No stock-photo fishing clichés (big trophy fish held to camera, forced smiles)
+- No unrealistic fish sizes or fantasy catches
+- No flags or political symbols
+
+---
+
+## Recurring Brand Elements (Use as Anchors)
+
+These elements reinforce the Norwegian coastal identity and can appear across images:
+
+- Weathered wooden dock or quay (brygge)
+- Traditional Norwegian boathouse / naust (red or ochre painted wood)
+- Flat-bottomed aluminium fishing boat (typical small-operator vessel)
+- Granite rocks at the waterline
+- Rope, nets, buoys — as texture, not as focal point
+- Grey or pale blue overcast Nordic sky
+- Calm fjord or sheltered coastal inlet
+- Distant mountain or headland silhouette
+
+---
+
+## Colour Reference
+
+| Role | Hex | Description |
+|------|-----|-------------|
+| Primary brand | `#2196f3` | Do NOT reproduce in images — it reads as digital/UI |
+| Water (deep) | `#1a3a5c` | Deep fjord navy for open water |
+| Water (shallow) | `#4a9b8e` | Fjord teal for sheltered inlets |
+| Granite | `#7a8b8b` | Weathered coastal rock |
+| Wood | `#8b6e4e` | Aged dock and boathouse timber |
+| Sky | `#c8d8e4` | Pale overcast Nordic sky |
+| Highlight | `#f0e8d0` | Soft morning light on water |
+
+---
+
+## Per-Article Scene Descriptions
+
+Append one of these after the Common Theme Prefix for each article.
+
+---
+
+### 1. `aldersgrense-turistfiske-12-ar.webp`
+**Article**: "Aldersgrense i turistfiske: hva gjelder for 12-åringer?"
+
+```
+Scene: A small aluminium fishing boat moored at a weathered wooden dock on a calm
+Norwegian fjord, seen from the dock level. A child's small rubber boot and an adult's
+boot are visible at the dock edge — feet only, no faces. A simple fishing rod leans
+against the dock railing. Early morning light, still water reflecting the grey sky.
+Mood: quiet, family, responsibility.
+```
+
+---
+
+### 2. `bot-for-turistfiske-rapportering.webp`
+**Article**: "Bot for turistfiske-rapportering?"
+
+```
+Scene: A traditional red Norwegian boathouse (naust) at dusk, its reflection broken
+in gently rippling water. The heavy wooden door is slightly ajar, warm light spilling
+from inside suggesting activity. A mooring rope is wrapped around a dock bollard in
+the foreground. Mood: seriousness, accountability, the weight of responsibility at
+end of day. No people visible.
+```
+
+---
+
+### 3. `daglig-fangstrapportering-turistfiske.webp`
+**Article**: "Daglig fangstrapportering i turistfiske"
+
+```
+Scene: Early morning on a Norwegian coastal quay. A fresh catch of cod (torsk) lies
+in a grey plastic fish crate on a wet dock, water droplets visible. In the soft
+background, a small aluminium boat is tied up and a boathouse silhouette is visible.
+The light is cool, diffuse, overcast — the start of a working day. No people.
+Mood: routine, precision, daily rhythm.
+```
+
+---
+
+### 4. `lovpalagt-fangstrapportering-fritidsboligeiere.webp`
+**Article**: "Lovpålagt fangstrapportering for fritidsboligeiere"
+
+```
+Scene: A traditional Norwegian cabin (hytte) by the water's edge, with a small dock
+and aluminium boat moored below. Shot from slightly above and behind, looking out
+over a calm fjord inlet. The cabin shows signs of active use — life vests hung on a
+railing, a pair of oars propped against the wall. Overcast Nordic light, grey-green
+water. Mood: ownership, stewardship, quiet obligation.
+```
+
+---
+
+### 5. `ma-du-registrere-turistfiskebedrift.webp`
+**Article**: "Må du registrere turistfiskebedrift?"
+
+```
+Scene: A small Norwegian harbour with two or three aluminium boats tied to a long
+weathered wooden dock. The boats are simple and functional — no luxury yachts.
+Granite rocks frame the foreground. In the far background, a cluster of red and
+white coastal buildings on a low hillside. Wide, open, Norwegian. Mood: threshold,
+decision, belonging to a regulated world. No people.
+```
+
+---
+
+### 6. `nullfangst-turistfiske-ma-det-rapporteres.webp`
+**Article**: "Nullfangst — må det rapporteres?"
+
+```
+Scene: An empty fishing boat on still, glassy fjord water at the end of the day.
+The boat is moored; the water surface is calm and mirror-like, reflecting an overcast
+pale grey sky. A single fishing line hangs slack over the side — nothing on it.
+The mood is quiet, slightly melancholic, honest. Shot from the dock, looking along
+the waterline. No people, no fish.
+```
+
+---
+
+### 7. `slik-kan-du-forberede-turistfiskesesongen.webp`
+**Article**: "Slik kan du forberede turistfiskesesongen"
+
+```
+Scene: A Norwegian boathouse and dock being readied for the season — life vests
+stacked and aired on a railing, a coil of rope neatly arranged on the dock,
+an aluminium boat freshly tied up. Early spring light: the snow has just left the
+mountains visible in the background, pale blue-grey water, cool clear air.
+A sense of purposeful preparation before guests arrive. No people, no faces.
+```
+
+---
+
+## Prompt Template Structure
+
+Final prompt = **Common Theme Prefix** + **Per-Article Scene Description**
+
+Example for article 3:
+
+```
+Photorealistic wide-format hero image for a Norwegian coastal fishing tourism website.
+Norwegian coastal palette: deep fjord navy (#1a3a5c), weathered granite grey,
+fjord teal (#4a9b8e), pale morning sky, and soft natural daylight — no saturated
+or tropical colours. [... full prefix ...] No flags or political symbols.
+
+Scene: Early morning on a Norwegian coastal quay. A fresh catch of cod (torsk) lies
+in a grey plastic fish crate on a wet dock, water droplets visible. [... etc ...]
+```
+
+---
+
+## Rationale: Why 1536 × 1024?
+
+- **On-page hero**: The image renders at its natural aspect ratio inside a `max-w-2xl` container — no cropping. At 800 px wide, a 3:2 image renders at ~533 px tall, giving a proper hero height. A 1.91:1 OG-ratio image would render only ~419 px tall — too flat for a hero.
+- **OG / social sharing**: `Layout.astro` hard-crops *any* source image to 1200 × 630 at build time, regardless of source dimensions. The source aspect ratio does **not** affect OG output.
+- **Consistency**: All 7 existing blog images are 1536 × 1024 (3:2). Matching this ensures a uniform visual language and predictable on-page rendering.
+
+---
+
+## Output Specifications for nano-banana
+
+- **Dimensions**: 1536 × 1024 px (3:2 ratio — matches all existing images)
+- **Format**: WebP
+- **File naming**: Match existing slug-based names (e.g. `daglig-fangstrapportering-turistfiske.webp`)
+- **Output path**: `/workspace/master/src/content/blog/images/`
+- **Quality target**: High fidelity, photorealistic — not illustration or painterly
+
+---
+
+*Last updated: 2026-04-26*

--- a/src/content/blog/HERO_IMAGE_GUIDELINES.md
+++ b/src/content/blog/HERO_IMAGE_GUIDELINES.md
@@ -89,117 +89,60 @@ These elements reinforce the Norwegian coastal identity and can appear across im
 
 ---
 
-## Per-Article Scene Descriptions
-
-Append one of these after the Common Theme Prefix for each article.
-
----
-
-### 1. `aldersgrense-turistfiske-12-ar.webp`
-**Article**: "Aldersgrense i turistfiske: hva gjelder for 12-åringer?"
-
-```
-Scene: A small aluminium fishing boat moored at a weathered wooden dock on a calm
-Norwegian fjord, seen from the dock level. A child's small rubber boot and an adult's
-boot are visible at the dock edge — feet only, no faces. A simple fishing rod leans
-against the dock railing. Early morning light, still water reflecting the grey sky.
-Mood: quiet, family, responsibility.
-```
-
----
-
-### 2. `bot-for-turistfiske-rapportering.webp`
-**Article**: "Bot for turistfiske-rapportering?"
-
-```
-Scene: A traditional red Norwegian boathouse (naust) at dusk, its reflection broken
-in gently rippling water. The heavy wooden door is slightly ajar, warm light spilling
-from inside suggesting activity. A mooring rope is wrapped around a dock bollard in
-the foreground. Mood: seriousness, accountability, the weight of responsibility at
-end of day. No people visible.
-```
-
----
-
-### 3. `daglig-fangstrapportering-turistfiske.webp`
-**Article**: "Daglig fangstrapportering i turistfiske"
-
-```
-Scene: Early morning on a Norwegian coastal quay. A fresh catch of cod (torsk) lies
-in a grey plastic fish crate on a wet dock, water droplets visible. In the soft
-background, a small aluminium boat is tied up and a boathouse silhouette is visible.
-The light is cool, diffuse, overcast — the start of a working day. No people.
-Mood: routine, precision, daily rhythm.
-```
-
----
-
-### 4. `lovpalagt-fangstrapportering-fritidsboligeiere.webp`
-**Article**: "Lovpålagt fangstrapportering for fritidsboligeiere"
-
-```
-Scene: A traditional Norwegian cabin (hytte) by the water's edge, with a small dock
-and aluminium boat moored below. Shot from slightly above and behind, looking out
-over a calm fjord inlet. The cabin shows signs of active use — life vests hung on a
-railing, a pair of oars propped against the wall. Overcast Nordic light, grey-green
-water. Mood: ownership, stewardship, quiet obligation.
-```
-
----
-
-### 5. `ma-du-registrere-turistfiskebedrift.webp`
-**Article**: "Må du registrere turistfiskebedrift?"
-
-```
-Scene: A small Norwegian harbour with two or three aluminium boats tied to a long
-weathered wooden dock. The boats are simple and functional — no luxury yachts.
-Granite rocks frame the foreground. In the far background, a cluster of red and
-white coastal buildings on a low hillside. Wide, open, Norwegian. Mood: threshold,
-decision, belonging to a regulated world. No people.
-```
-
----
-
-### 6. `nullfangst-turistfiske-ma-det-rapporteres.webp`
-**Article**: "Nullfangst — må det rapporteres?"
-
-```
-Scene: An empty fishing boat on still, glassy fjord water at the end of the day.
-The boat is moored; the water surface is calm and mirror-like, reflecting an overcast
-pale grey sky. A single fishing line hangs slack over the side — nothing on it.
-The mood is quiet, slightly melancholic, honest. Shot from the dock, looking along
-the waterline. No people, no fish.
-```
-
----
-
-### 7. `slik-kan-du-forberede-turistfiskesesongen.webp`
-**Article**: "Slik kan du forberede turistfiskesesongen"
-
-```
-Scene: A Norwegian boathouse and dock being readied for the season — life vests
-stacked and aired on a railing, a coil of rope neatly arranged on the dock,
-an aluminium boat freshly tied up. Early spring light: the snow has just left the
-mountains visible in the background, pale blue-grey water, cool clear air.
-A sense of purposeful preparation before guests arrive. No people, no faces.
-```
-
----
-
 ## Prompt Template Structure
 
 Final prompt = **Common Theme Prefix** + **Per-Article Scene Description**
 
-Example for article 3:
+The Common Theme Prefix is reusable and never changes. The scene description is
+written fresh for each new article from the article's content, following the
+methodology below.
+
+---
+
+## How to Derive a Scene from a New Article
+
+When generating a hero for a new blog post, work through these steps:
+
+1. **Read the article** and identify its core theme in one sentence (e.g.
+   "the legal duty to report catches", "preparing for the season").
+2. **Pick a single concrete object or moment** that anchors the theme — not a
+   metaphor, not a person performing an action. A boot at a dock edge, a fish
+   crate on a wet quay, a rope coiled on a bollard. One readable focal point.
+3. **Choose a setting** from the Recurring Brand Elements list (dock, naust,
+   aluminium boat, fjord, hytte, harbour). Mix two if it adds depth, no more.
+4. **Set the time of day and weather** to match the article's emotional tone:
+   - Bright, purposeful topic → soft early-morning light, calm water
+   - Serious, regulatory topic → overcast grey, dusk, muted palette
+   - Reflective, melancholic topic → glassy still water, flat pale sky
+   - Forward-looking, seasonal → spring light, snow leaving the mountains
+5. **Name the mood explicitly** in one phrase ("quiet responsibility",
+   "purposeful preparation", "honest accountability"). The model uses this
+   to colour-grade and compose.
+6. **Write the scene as 3–5 sentences** in plain English. Lead with the
+   focal object, then the setting, then the light, then the mood.
+   No people's faces. No text. No screens.
+7. **Append it after the Common Theme Prefix verbatim** and feed the combined
+   prompt to nano-banana. Save output to
+   `src/content/blog/images/<article-slug>.webp`.
+
+### Worked Example
+
+Article: "Daglig fangstrapportering i turistfiske" (daily catch reporting)
+
+- Core theme: *the daily routine of logging a catch*
+- Focal object: *a fish crate with fresh cod on a wet dock*
+- Setting: *coastal quay with boat in the soft background*
+- Time/weather: *early morning, overcast, cool diffuse light*
+- Mood: *routine, precision, daily rhythm*
+
+Resulting scene description:
 
 ```
-Photorealistic wide-format hero image for a Norwegian coastal fishing tourism website.
-Norwegian coastal palette: deep fjord navy (#1a3a5c), weathered granite grey,
-fjord teal (#4a9b8e), pale morning sky, and soft natural daylight — no saturated
-or tropical colours. [... full prefix ...] No flags or political symbols.
-
-Scene: Early morning on a Norwegian coastal quay. A fresh catch of cod (torsk) lies
-in a grey plastic fish crate on a wet dock, water droplets visible. [... etc ...]
+Scene: Early morning on a Norwegian coastal quay. A fresh catch of cod (torsk)
+lies in a grey plastic fish crate on a wet dock, water droplets visible. In the
+soft background, a small aluminium boat is tied up and a boathouse silhouette is
+visible. The light is cool, diffuse, overcast — the start of a working day.
+No people. Mood: routine, precision, daily rhythm.
 ```
 
 ---

--- a/src/pages/blogg/[...slug].astro
+++ b/src/pages/blogg/[...slug].astro
@@ -17,6 +17,10 @@ const { Content } = await render(entry);
 const siteUrl = 'https://eksportfiske.no';
 const canonicalURL = `${siteUrl}/blogg/${entry.id}`;
 
+const encodedURL = encodeURIComponent(canonicalURL);
+const encodedTitle = encodeURIComponent(entry.data.title);
+const encodedWhatsApp = encodeURIComponent(`${entry.data.title} ${canonicalURL}`);
+
 function formatDate(date: Date): string {
   return date.toLocaleDateString('nb-NO', {
     day: 'numeric',
@@ -105,6 +109,98 @@ const jsonLd = {
       <footer class="mt-12 pt-6 border-t border-gray-200 text-sm text-gray-500">
         Skrevet med hjelp av KI.
       </footer>
+
+      <!-- Share buttons -->
+      <div class="mt-8 pt-6 border-t border-gray-100">
+        <p class="text-sm font-semibold text-gray-700 mb-4">Del denne artikkelen</p>
+        <div class="flex flex-wrap gap-3">
+
+          <!-- Facebook -->
+          <a
+            href={`https://www.facebook.com/sharer/sharer.php?u=${encodedURL}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Del på Facebook"
+            title="Del på Facebook"
+            class="inline-flex items-center justify-center w-11 h-11 rounded-lg border border-gray-300 text-gray-600 hover:bg-gray-100 hover:border-gray-400 transition-colors"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5" aria-hidden="true">
+              <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
+            </svg>
+          </a>
+
+          <!-- X / Twitter -->
+          <a
+            href={`https://twitter.com/intent/tweet?url=${encodedURL}&text=${encodedTitle}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Del på X (Twitter)"
+            title="Del på X (Twitter)"
+            class="inline-flex items-center justify-center w-11 h-11 rounded-lg border border-gray-300 text-gray-600 hover:bg-gray-100 hover:border-gray-400 transition-colors"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5" aria-hidden="true">
+              <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.745l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+            </svg>
+          </a>
+
+          <!-- LinkedIn -->
+          <a
+            href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodedURL}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Del på LinkedIn"
+            title="Del på LinkedIn"
+            class="inline-flex items-center justify-center w-11 h-11 rounded-lg border border-gray-300 text-gray-600 hover:bg-gray-100 hover:border-gray-400 transition-colors"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5" aria-hidden="true">
+              <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
+            </svg>
+          </a>
+
+          <!-- WhatsApp -->
+          <a
+            href={`https://wa.me/?text=${encodedWhatsApp}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Del på WhatsApp"
+            title="Del på WhatsApp"
+            class="inline-flex items-center justify-center w-11 h-11 rounded-lg border border-gray-300 text-gray-600 hover:bg-gray-100 hover:border-gray-400 transition-colors"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5" aria-hidden="true">
+              <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z"/>
+            </svg>
+          </a>
+
+          <!-- Email -->
+          <a
+            href={`mailto:?subject=${encodedTitle}&body=${encodedURL}`}
+            aria-label="Del via e-post"
+            title="Del via e-post"
+            class="inline-flex items-center justify-center w-11 h-11 rounded-lg border border-gray-300 text-gray-600 hover:bg-gray-100 hover:border-gray-400 transition-colors"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5" aria-hidden="true">
+              <rect width="20" height="16" x="2" y="4" rx="2"/>
+              <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/>
+            </svg>
+          </a>
+
+          <!-- Copy link -->
+          <button
+            id="copy-link-btn"
+            data-url={canonicalURL}
+            aria-label="Kopier lenke"
+            title="Kopier lenke"
+            type="button"
+            class="inline-flex items-center justify-center w-11 h-11 rounded-lg border border-gray-300 text-gray-600 hover:bg-gray-100 hover:border-gray-400 transition-colors"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5" aria-hidden="true">
+              <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/>
+              <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
+            </svg>
+          </button>
+
+        </div>
+      </div>
     </div>
   </article>
 
@@ -134,6 +230,34 @@ const jsonLd = {
     </div>
   </section>
 </Layout>
+
+<script>
+  const btn = document.getElementById('copy-link-btn');
+  if (btn) {
+    // Capture the link icon HTML before any mutations
+    const linkSvg = btn.innerHTML;
+    const checkSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>`;
+
+    btn.addEventListener('click', async () => {
+      const url = btn.getAttribute('data-url') ?? '';
+      try {
+        await navigator.clipboard.writeText(url);
+        btn.innerHTML = checkSvg;
+        btn.setAttribute('aria-label', 'Kopiert!');
+        btn.style.borderColor = '#22c55e';
+        btn.style.color = '#16a34a';
+        setTimeout(() => {
+          btn.innerHTML = linkSvg;
+          btn.setAttribute('aria-label', 'Kopier lenke');
+          btn.style.borderColor = '';
+          btn.style.color = '';
+        }, 2000);
+      } catch {
+        // Clipboard API unavailable — silently ignore
+      }
+    });
+  }
+</script>
 
 <style>
   .article-body :global(h2) {


### PR DESCRIPTION
## Summary
- Legger til delingsknapper (Facebook, X, LinkedIn, WhatsApp, e-post, kopier lenke) nederst i alle blogginnlegg, med norske aria-labels og 44px tap-targets.
- Etablerer felles visuell mal for blogg-heltebilder i `src/content/blog/HERO_IMAGE_GUIDELINES.md` — nano-banana-prompt-prefix pluss scenebeskrivelser for hver av de 7 eksisterende artiklene.
- Ekskluderer den nye guideline-fila fra blogg-collection-globben (samme mønster som `REVIEW_GUIDELINES.md`).

## Test plan
- [ ] Åpne et blogginnlegg lokalt og bekreft at delingsknappene vises nederst
- [ ] Test hver knapp: Facebook, X, LinkedIn, WhatsApp, e-post åpner riktig dialog
- [ ] Test kopier-lenke: bytter til grønn checkmark i 2 sekunder
- [ ] Verifiser at byggingen fortsatt produserer 17 sider uten feil
- [ ] Sjekk tilgjengelighet med tastatur og skjermleser