### PR TITLE
Perf: PSI mobile improvements

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,10 @@ export default defineConfig({
   site: 'https://eksportfiske.no',
   base: '',
 
+  build: {
+    inlineStylesheets: 'auto',
+  },
+
   vite: {
     plugins: [tailwindcss()]
   },

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -252,11 +252,25 @@ const ogImageURL = new URL(ogImage.src, siteUrl).href;
       });
     </script>
 
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-TH0VD36D5C"></script>
+    <!-- Google tag (gtag.js) - deferred until after load/idle to avoid forced reflow during LCP -->
     <script is:inline>
-      gtag('js', new Date());
-      gtag('config', 'G-TH0VD36D5C');
+      window.addEventListener('load', function() {
+        function loadGtag() {
+          var s = document.createElement('script');
+          s.async = true;
+          s.src = 'https://www.googletagmanager.com/gtag/js?id=G-TH0VD36D5C';
+          s.onload = function() {
+            gtag('js', new Date());
+            gtag('config', 'G-TH0VD36D5C');
+          };
+          document.head.appendChild(s);
+        }
+        if ('requestIdleCallback' in window) {
+          requestIdleCallback(loadGtag, { timeout: 2000 });
+        } else {
+          setTimeout(loadGtag, 1000);
+        }
+      });
     </script>
 
     <!-- Meta Pixel - deferred until consent is granted.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -36,11 +36,12 @@ const ogImageAltText = ogImageAlt ?? 'export.fish - Fangstrapportering for turis
 // Hero preload — generate multiple widths so browsers pick the right variant.
 // The imagesrcset/imagesizes on the <link> mirror what the <Image> component
 // renders, so mobile browsers fetch the small variant instead of the 1920w one.
+// quality: 75 — background image, text overlay, safe to go below default 80.
 const [heroSm, heroMd, heroLg, heroXl] = await Promise.all([
-  getImage({ src: defaultOgImage, format: 'webp', width: 640 }),
-  getImage({ src: defaultOgImage, format: 'webp', width: 1024 }),
-  getImage({ src: defaultOgImage, format: 'webp', width: 1280 }),
-  getImage({ src: defaultOgImage, format: 'webp', width: 1920 }),
+  getImage({ src: defaultOgImage, format: 'webp', width: 640, quality: 75 }),
+  getImage({ src: defaultOgImage, format: 'webp', width: 1024, quality: 75 }),
+  getImage({ src: defaultOgImage, format: 'webp', width: 1280, quality: 75 }),
+  getImage({ src: defaultOgImage, format: 'webp', width: 1920, quality: 75 }),
 ]);
 const heroPreloadSrcset = `${heroSm.src} 640w, ${heroMd.src} 1024w, ${heroLg.src} 1280w, ${heroXl.src} 1920w`;
 const heroPreload = heroXl; // fallback href points at the largest
@@ -315,7 +316,7 @@ const ogImageURL = new URL(ogImage.src, siteUrl).href;
     <header class="fixed top-0 w-full bg-white/90 backdrop-blur-sm border-b border-gray-200 z-50">
       <nav class="container mx-auto px-4 py-4 flex justify-between items-center">
         <a href="/" class="flex items-center gap-3 group">
-          <Image src={logo} alt="export.fish logo" width={80} height={80} class="h-16 w-16 md:h-20 md:w-20 transition-transform group-hover:scale-110" />
+          <Image src={logo} alt="export.fish logo" width={80} height={80} densities={[1, 2]} class="h-16 w-16 md:h-20 md:w-20 transition-transform group-hover:scale-110" />
           <span class="text-2xl md:text-3xl font-bold text-primary">Eksportfiske</span>
         </a>
         <!-- Mobile menu (hamburger) -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,7 +29,7 @@ import logo from '../assets/logo.png';
   <section class="relative pt-52 pb-32 md:pb-40 text-white overflow-hidden" aria-labelledby="hero-heading">
     <!-- Background Image -->
     <div class="absolute inset-0 hero-bg-fade" aria-hidden="true">
-      <Image src={heroBg} alt="" class="w-full h-full object-cover" widths={[640, 1024, 1280, 1920]} sizes="100vw" loading="eager" fetchpriority="high" />
+      <Image src={heroBg} alt="" class="w-full h-full object-cover" widths={[640, 1024, 1280, 1920]} sizes="100vw" loading="eager" fetchpriority="high" quality={75} />
       <div class="absolute inset-0 bg-gradient-to-br from-blue-400/75 via-blue-500/80 to-blue-600/85"></div>
     </div>
 
@@ -750,7 +750,7 @@ import logo from '../assets/logo.png';
                 <svg class="w-5 h-5 text-green-600 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
                   <path d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" fill-rule="evenodd"></path>
                 </svg>
-                <span>Kan avsluttes når som helst via e-post til <a href="mailto:kontakt@eksportfiske.no" class="text-primary hover:underline">kontakt@eksportfiske.no</a></span>
+                <span>Kan avsluttes når som helst via e-post til <a href="mailto:kontakt@eksportfiske.no" class="text-primary hover:underline"><!--email_off-->kontakt@eksportfiske.no<!--/email_off--></a></span>
               </li>
             </ul>
             <p class="mt-3 text-sm">
@@ -1043,7 +1043,7 @@ import logo from '../assets/logo.png';
           <ul class="space-y-2 text-sm">
             <li>
               <a href="mailto:kontakt@eksportfiske.no" class="hover:text-primary transition">
-                kontakt@eksportfiske.no
+                <!--email_off-->kontakt@eksportfiske.no<!--/email_off-->
               </a>
             </li>
             <li>

--- a/src/pages/kontakt.astro
+++ b/src/pages/kontakt.astro
@@ -39,7 +39,7 @@ import Layout from '../layouts/Layout.astro';
           href="mailto:kontakt@eksportfiske.no"
           class="inline-block text-xl md:text-2xl text-primary hover:text-primary-hover font-semibold mb-8 transition-colors group"
         >
-          <span class="group-hover:underline">kontakt@eksportfiske.no</span>
+          <span class="group-hover:underline"><!--email_off-->kontakt@eksportfiske.no<!--/email_off--></span>
         </a>
 
         <!-- Additional Info -->

--- a/src/pages/om-oss.astro
+++ b/src/pages/om-oss.astro
@@ -58,7 +58,7 @@ import Layout from '../layouts/Layout.astro';
           href="mailto:kontakt@eksportfiske.no"
           class="inline-block text-lg text-primary hover:text-primary-hover font-semibold transition-colors hover:underline"
         >
-          kontakt@eksportfiske.no
+          <!--email_off-->kontakt@eksportfiske.no<!--/email_off-->
         </a>
 
       </div>


### PR DESCRIPTION
## Summary

- **GA defer**: gtag.js loaded via `requestIdleCallback` after `load` event, avoiding forced reflow during LCP
- **Hero recompression**: Hero WebP at quality 75 across all breakpoints — 1920w down from 326 KB to 279 KB (~14% reduction)
- **Retina nav logo**: `densities={[1, 2]}` on nav logo generates a 2x WebP srcset variant for HiDPI/retina screens
- **Inline CSS**: `build: { inlineStylesheets: 'auto' }` in astro.config.mjs eliminates render-blocking `<link rel="stylesheet">` for Layout CSS on the homepage
- **Email obfuscation**: Bare email addresses wrapped in `<!--email_off-->` markers to prevent Cloudflare injecting `email-decode.min.js` into the critical path

## What is NOT in this PR (Cloudflare config)

The most impactful remaining fix requires a manual Cloudflare change:

- **Cache TTL**: `/_astro/*` assets have content-hash filenames and should be served with `Cache-Control: max-age=31536000, immutable`. Add a Cloudflare Cache Rule: URL path matches `/_astro/*` → Edge Cache TTL 1 year, Browser TTL 1 year.
- **Email obfuscation OFF** (alternative to code-side markers): Cloudflare dashboard → Scrape Shield → Email Address Obfuscation → toggle off. The `<!--email_off-->` markers in this PR are the code-side opt-out and should work without the dashboard change, but disabling globally is cleaner.

## Test plan

- [x] `npx astro build` succeeds with no errors
- [x] `dist/index.html` has no render-blocking `<link rel="stylesheet">` for Layout CSS
- [x] `dist/_astro/hero-bg.*1920w.webp` is 279 KB (was 326 KB)
- [x] Nav logo srcset includes a 2x variant (`logo.*.webp 2x`)
- [x] Bare email addresses in index.html, kontakt.html, om-oss.html wrapped in `<!--email_off-->` markers
- [x] Email in JSON-LD structured data (script tag) left unwrapped — Cloudflare does not obfuscate inside script tags