### PR TITLE
SEO: dynamisk robots.txt via Astro-endepunkt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,7 +1,0 @@
-User-agent: *
-Allow: /
-
-Sitemap: https://eksportfiske.no/sitemap-index.xml
-
-# Block build artifacts (if needed in future)
-Disallow: /_astro/

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,0 +1,16 @@
+import type { APIRoute } from 'astro';
+
+const robotsTxt = (site: URL) => `User-agent: *
+Allow: /
+
+Sitemap: ${new URL('sitemap-index.xml', site).href}
+`;
+
+export const GET: APIRoute = ({ site }) => {
+  if (!site) {
+    throw new Error('Astro.site is not configured. Set `site` in astro.config.mjs.');
+  }
+  return new Response(robotsTxt(site), {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+};


### PR DESCRIPTION
## Summary

- Replaces static `public/robots.txt` with a dynamic API endpoint at `src/pages/robots.txt.ts`
- Drops the harmful `Disallow: /_astro/` directive that was blocking Googlebot from fetching CSS/JS needed to render and score the page (flagged in Search Console)
- Uses `Astro.site` for the sitemap URL so the domain is never hardcoded

## Why

The static file had three problems: it blocked `/_astro/` (Googlebot penalty), the sitemap line was positioned in the middle, and a dead comment cluttered the file. The dynamic endpoint is the idiomatic Astro approach — no new dependencies, auto-picks up the configured `site` value, and is easy to extend with per-environment logic if needed later.

Cloudflare's "Managed Robots.txt" continues to prepend AI-bot blocks (`GPTBot`, `ClaudeBot`, `CCBot`, etc.) at the edge via Crawl Control — unchanged, not duplicated here.

## Test plan

- [x] `npx astro build` succeeds — endpoint rendered as `λ src/pages/robots.txt.ts`
- [x] `dist/robots.txt` contains exactly: `User-agent: *`, `Allow: /`, blank line, `Sitemap: https://eksportfiske.no/sitemap-index.xml`, trailing newline
- [x] No `Disallow: /_astro/` in output
- [ ] Dev server: `GET /robots.txt` returns `Content-Type: text/plain; charset=utf-8`