### PR TITLE
SEO: agent readiness

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,7 @@ import { defineConfig } from 'astro/config';
 import tailwindcss from '@tailwindcss/vite';
 
 import sitemap from '@astrojs/sitemap';
+import markdownOutput from './src/integrations/markdown-output.ts';
 
 // https://astro.build/config
 export default defineConfig({
@@ -18,7 +19,10 @@ export default defineConfig({
     plugins: [tailwindcss()]
   },
 
-  integrations: [sitemap({
-    filter: (page) => !page.includes('/registrer/takk') && !page.includes('/qr')
-  })]
+  integrations: [
+    sitemap({
+      filter: (page) => !page.includes('/registrer/takk') && !page.includes('/qr')
+    }),
+    markdownOutput(),
+  ]
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
+        "@types/turndown": "^5.0.6",
+        "cheerio": "^1.2.0",
         "fast-xml-parser": "^5.7.1",
         "sharp": "^0.34.5",
         "turndown": "^7.2.4"
@@ -201,6 +203,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.0.tgz",
       "integrity": "sha512-oAYoQnCYaQZKVS53Fq23ceWMRxq5EhQsE0x0RdQ55jT7wagMu5k+fS39v1fiSLrtrLQlXwVINenqhLMtTrV/1Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -640,6 +643,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -662,6 +666,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -684,6 +689,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -700,6 +706,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -716,6 +723,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -732,6 +740,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -748,6 +757,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -764,6 +774,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -780,6 +791,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -796,6 +808,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -812,6 +825,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -828,6 +842,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -844,6 +859,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -866,6 +882,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -888,6 +905,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -910,6 +928,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -932,6 +951,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -954,6 +974,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -976,6 +997,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -998,6 +1020,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1020,6 +1043,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1039,6 +1063,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1058,6 +1083,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1077,6 +1103,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1990,6 +2017,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/turndown": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
+      "integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2207,6 +2241,50 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/chokidar": {
@@ -2546,6 +2624,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -2989,11 +3081,57 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
@@ -4400,6 +4538,33 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-expression-matcher": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
@@ -4795,6 +4960,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/sax": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
@@ -5103,6 +5275,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -5137,6 +5310,16 @@
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
@@ -5536,6 +5719,30 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which-pm-runs": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@types/turndown": "^5.0.6",
+    "cheerio": "^1.2.0",
     "fast-xml-parser": "^5.7.1",
     "sharp": "^0.34.5",
     "turndown": "^7.2.4"

--- a/src/integrations/markdown-output.ts
+++ b/src/integrations/markdown-output.ts
@@ -1,0 +1,222 @@
+/**
+ * Astro integration: markdown-output
+ *
+ * After the build completes, walks dist/ and converts every HTML page to a
+ * clean Markdown file at <path>.md so AI agents can fetch readable content
+ * without parsing the full HTML.
+ *
+ * For dist/blog/sjekkliste/index.html  →  dist/blog/sjekkliste.md
+ * For dist/index.html                  →  dist/index.md
+ */
+
+import type { AstroIntegration } from 'astro';
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, dirname, basename } from 'node:path';
+import { load } from 'cheerio';
+import TurndownService from 'turndown';
+
+// Pages we deliberately skip — they are not prose pages.
+const SKIP_PATTERNS = [
+  /\b404\b/,
+  /sitemap/,
+  /robots/,
+  /agent-skills/,
+  /qr\//,
+  /registrer\/takk/,
+];
+
+function shouldSkip(relPath: string): boolean {
+  return SKIP_PATTERNS.some((p) => p.test(relPath));
+}
+
+/**
+ * Walk a directory recursively, yielding absolute paths to all .html files.
+ */
+function* walkHtml(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      yield* walkHtml(full);
+    } else if (entry.endsWith('.html')) {
+      yield full;
+    }
+  }
+}
+
+/**
+ * Derive the canonical URL path from the HTML file's location in dist/.
+ *
+ * dist/index.html              → /
+ * dist/blog/sjekkliste/index.html → /blog/sjekkliste/
+ * dist/kontakt/index.html      → /kontakt/
+ */
+function htmlToUrlPath(distDir: string, htmlFile: string): string {
+  const rel = relative(distDir, htmlFile); // e.g. "blog/sjekkliste/index.html"
+  const parts = rel.replace(/\\/g, '/').split('/');
+  if (parts[parts.length - 1] === 'index.html') {
+    parts.pop();
+  } else {
+    parts[parts.length - 1] = parts[parts.length - 1].replace(/\.html$/, '');
+  }
+  return '/' + parts.join('/') + (parts.length > 0 ? '/' : '');
+}
+
+/**
+ * Where to write the .md file, given the HTML file path.
+ *
+ * Convention:  dist/foo/index.html  →  dist/foo.md
+ *              dist/index.html      →  dist/index.md
+ *
+ * This means the URL /foo.md (or /foo/index.md) will serve the file.
+ * GitHub Pages resolves /foo.md directly; both conventions work.
+ */
+function mdOutputPath(distDir: string, htmlFile: string): string {
+  const rel = relative(distDir, htmlFile); // "blog/sjekkliste/index.html"
+  const normalized = rel.replace(/\\/g, '/');
+
+  if (normalized === 'index.html') {
+    // dist/index.html → dist/index.md
+    return join(distDir, 'index.md');
+  }
+
+  if (normalized.endsWith('/index.html')) {
+    // dist/blog/sjekkliste/index.html → dist/blog/sjekkliste.md
+    const withoutIndex = normalized.slice(0, -'/index.html'.length); // "blog/sjekkliste"
+    return join(distDir, withoutIndex + '.md');
+  }
+
+  // dist/kontakt.html → dist/kontakt.md (non-pretty-URL page, rare in Astro)
+  return htmlFile.replace(/\.html$/, '.md');
+}
+
+/**
+ * Configure Turndown for clean Markdown output.
+ */
+function buildTurndown(): TurndownService {
+  const td = new TurndownService({
+    headingStyle: 'atx',       // # ## ###
+    bulletListMarker: '-',
+    codeBlockStyle: 'fenced',
+  });
+
+  // Handle <picture> elements: extract the inner <img> src/alt instead of
+  // trying to markdown the source/srcset children.
+  td.addRule('picture', {
+    filter: 'picture',
+    replacement(_content: string, node: TurndownService.Node) {
+      const el = node as unknown as Element;
+      const img = el.querySelector?.('img');
+      if (!img) return '';
+      const src = img.getAttribute('src') ?? '';
+      const alt = img.getAttribute('alt') ?? '';
+      return src ? `![${alt}](${src})` : '';
+    },
+  });
+
+  // Drop <source> elements (they're inside <picture> and handled above).
+  td.addRule('source', {
+    filter: 'source',
+    replacement: () => '',
+  });
+
+  return td;
+}
+
+/**
+ * Extract meaningful content from the HTML, stripping chrome.
+ */
+function extractContent(html: string): {
+  title: string;
+  description: string;
+  bodyHtml: string;
+} {
+  const $ = load(html);
+
+  const title = $('title').first().text().trim();
+  const description = $('meta[name="description"]').attr('content')?.trim() ?? '';
+
+  // Remove boilerplate elements before selecting content.
+  $('nav, header, footer, script, style, noscript, [aria-hidden="true"]').remove();
+  // Also remove the cookie consent banner and any fixed overlays.
+  $('[class*="cookie"], [id*="cookie"], [class*="consent"], [id*="consent"]').remove();
+
+  // Try main > article > body in order.
+  let content = $('main').first();
+  if (!content.length) {
+    content = $('article').first();
+  }
+  if (!content.length) {
+    content = $('body');
+  }
+
+  const bodyHtml = content.html() ?? '';
+  return { title, description, bodyHtml };
+}
+
+/**
+ * Build YAML frontmatter block.
+ */
+function frontmatter(title: string, description: string, pageUrl: string): string {
+  // Escape double quotes inside values.
+  const esc = (s: string) => s.replace(/"/g, '\\"');
+  return [
+    '---',
+    `title: "${esc(title)}"`,
+    `description: "${esc(description)}"`,
+    `url: "${esc(pageUrl)}"`,
+    '---',
+    '',
+  ].join('\n');
+}
+
+export default function markdownOutput(): AstroIntegration {
+  return {
+    name: 'markdown-output',
+    hooks: {
+      'astro:build:done': async ({ dir, logger }) => {
+        const td = buildTurndown();
+        // dir is a URL object, convert to path string
+        const distDir = dir instanceof URL ? dir.pathname : String(dir);
+        const siteBase = 'https://eksportfiske.no';
+
+        let generated = 0;
+        let skipped = 0;
+
+        for (const htmlFile of walkHtml(distDir)) {
+          const relPath = relative(distDir, htmlFile).replace(/\\/g, '/');
+
+          if (shouldSkip(relPath)) {
+            skipped++;
+            continue;
+          }
+
+          try {
+            const html = readFileSync(htmlFile, 'utf-8');
+            const { title, description, bodyHtml } = extractContent(html);
+
+            if (!bodyHtml.trim()) {
+              skipped++;
+              continue;
+            }
+
+            const urlPath = htmlToUrlPath(distDir, htmlFile);
+            const pageUrl = siteBase + urlPath;
+            const markdown = td.turndown(bodyHtml);
+
+            const fm = frontmatter(title, description, pageUrl);
+            const output = fm + markdown + '\n';
+
+            const outPath = mdOutputPath(distDir, htmlFile);
+            writeFileSync(outPath, output, 'utf-8');
+            generated++;
+          } catch (err) {
+            logger.warn(`markdown-output: failed to process ${relPath}: ${err}`);
+          }
+        }
+
+        logger.info(`markdown-output: generated ${generated} .md files (${skipped} skipped)`);
+      },
+    },
+  };
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -50,6 +50,11 @@ const favicon = '/favicon.svg';
 const siteUrl = 'https://eksportfiske.no';
 const canonicalURL = new URL(Astro.url.pathname, siteUrl).href;
 const ogImageURL = new URL(ogImage.src, siteUrl).href;
+
+// Markdown alternate URL: /blog/sjekkliste/ → /blog/sjekkliste.md
+// Homepage (/) → /index.md
+const _mdPathname = Astro.url.pathname.replace(/\/$/, '') || '/index';
+const markdownURL = new URL(_mdPathname + '.md', siteUrl).href;
 ---
 
 <!doctype html>
@@ -75,7 +80,7 @@ const ogImageURL = new URL(ogImage.src, siteUrl).href;
     <!-- Agent discovery -->
     <link rel="sitemap" type="application/xml" href="/sitemap-index.xml" />
     <link rel="agent-skills" href="/.well-known/agent-skills/index.json" />
-    <link rel="alternate" type="text/markdown" href={canonicalURL} />
+    <link rel="alternate" type="text/markdown" href={markdownURL} />
 
     <!-- Open Graph -->
     <meta property="og:type" content={ogType} />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -72,6 +72,11 @@ const ogImageURL = new URL(ogImage.src, siteUrl).href;
     <!-- Canonical URL -->
     <link rel="canonical" href={canonicalURL} />
 
+    <!-- Agent discovery -->
+    <link rel="sitemap" type="application/xml" href="/sitemap-index.xml" />
+    <link rel="agent-skills" href="/.well-known/agent-skills/index.json" />
+    <link rel="alternate" type="text/markdown" href={canonicalURL} />
+
     <!-- Open Graph -->
     <meta property="og:type" content={ogType} />
     <meta property="og:url" content={canonicalURL} />

--- a/src/pages/.well-known/agent-skills/index.json.ts
+++ b/src/pages/.well-known/agent-skills/index.json.ts
@@ -9,7 +9,7 @@ const agentSkills = (site: URL) =>
           name: 'register-turistfiskebedrift',
           type: 'form',
           description:
-            'Registrer din turistfiskebedrift hos Fiskeridirektoratet via vårt skjema',
+            'Registrer turistfiskebedriften din i export.fish-appen for å rapportere fangst',
           url: new URL('registrer', site).href,
         },
       ],

--- a/src/pages/.well-known/agent-skills/index.json.ts
+++ b/src/pages/.well-known/agent-skills/index.json.ts
@@ -1,0 +1,28 @@
+import type { APIRoute } from 'astro';
+
+const agentSkills = (site: URL) =>
+  JSON.stringify(
+    {
+      $schema: 'https://agentskills.io/schemas/v0.2.0/agent-skills.schema.json',
+      skills: [
+        {
+          name: 'register-turistfiskebedrift',
+          type: 'form',
+          description:
+            'Registrer din turistfiskebedrift hos Fiskeridirektoratet via vårt skjema',
+          url: new URL('registrer', site).href,
+        },
+      ],
+    },
+    null,
+    2,
+  );
+
+export const GET: APIRoute = ({ site }) => {
+  if (!site) {
+    throw new Error('Astro.site is not configured. Set `site` in astro.config.mjs.');
+  }
+  return new Response(agentSkills(site), {
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+  });
+};

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 
 const robotsTxt = (site: URL) => `User-agent: *
+Content-Signal: search=yes, ai-train=yes, ai-input=yes
 Allow: /
 
 Sitemap: ${new URL('sitemap-index.xml', site).href}


### PR DESCRIPTION
## Summary

- **robots.txt content signals** — added \`Content-Signal: search=yes, ai-train=yes, ai-input=yes\` under \`User-agent: *\`, making the existing AI-crawl consent explicit per the contentsignals.org draft spec
- **Discovery link tags in layout head** — added three \`<link>\` tags to \`src/layouts/Layout.astro\`: \`rel=\"sitemap\"\` (redundant but machine-readable), \`rel=\"agent-skills\"\` pointing at the index below, and \`rel=\"alternate\" type=\"text/markdown\"\` pointing at the static per-page \`.md\` URL
- **Agent skills discovery index** — new static endpoint \`src/pages/.well-known/agent-skills/index.json.ts\` serving \`/.well-known/agent-skills/index.json\` per the Cloudflare agent-skills-discovery RFC v0.2.0; advertises the registration form as an agent-callable skill
- **Static markdown output for all pages** — new Astro integration \`src/integrations/markdown-output.ts\` runs after build, walks \`dist/\` and converts every HTML page to a clean \`.md\` file. Uses \`turndown\` (HTML→Markdown) and \`cheerio\` (HTML parsing). Strips nav/header/footer/scripts and writes YAML frontmatter (title, description, canonical URL). Results: 21 \`.md\` files generated at build time, available at static URLs like \`/index.md\`, \`/blogg/sjekkliste-hytte-bat.md\`, \`/kontakt.md\`, etc. No server-side content negotiation needed.

## How markdown URLs work

Each HTML page at \`/foo/\` gets a corresponding \`/foo.md\` file (homepage: \`/index.md\`). The \`<link rel="alternate" type="text/markdown">\` tag in every page's \`<head>\` points to the correct per-page \`.md\` URL so agents can discover it from the HTML.

Skipped pages: 404, qr/, registrer/takk, sitemap, robots, agent-skills index.

## What is not in this PR and why

- **API catalog** (\`/.well-known/api-catalog\`) — eksportfiske.no is a static marketing site with no public API on this domain. The backend registration endpoint lives at \`export.fish/v1/business-owners/register\` on a separate host. Could be added as a stub pointing to that host if desired (open a separate issue).
- **OAuth/OIDC discovery** (\`/.well-known/openid-configuration\` etc.) — no auth flows on this domain.
- **OAuth Protected Resource Metadata** (\`/.well-known/oauth-protected-resource\`) — no protected resources on this domain.
- **MCP Server Card** (\`/.well-known/mcp/server-card.json\`) — no MCP server. Could be a future opportunity for the export.fish backend.
- **WebMCP** (\`navigator.modelContext.provideContext()\`) — proposal-stage browser API, not yet widely shipped. Worth revisiting in 6-12 months.

## Test plan

- [x] \`npm run build\` succeeds with no errors
- [x] \`dist/robots.txt\` contains \`Content-Signal: search=yes, ai-train=yes, ai-input=yes\`
- [x] \`dist/.well-known/agent-skills/index.json\` exists, is valid JSON, contains \`register-turistfiskebedrift\` skill
- [x] \`dist/index.html\` contains all three \`<link>\` tags under \`<!-- Agent discovery -->\` comment
- [x] \`dist/index.md\` exists with YAML frontmatter and clean markdown body (no nav/footer boilerplate)
- [x] \`dist/blogg/leie-hytte-med-bat-sjekkliste.md\` exists with correct content
- [x] \`dist/kontakt.md\`, \`dist/om-oss.md\`, \`dist/registrer.md\` exist
- [x] \`<link rel="alternate" type="text/markdown">\` in homepage HTML points to \`https://eksportfiske.no/index.md\`
- [x] \`<link rel="alternate" type="text/markdown">\` in blog post HTML points to \`https://eksportfiske.no/blogg/leie-hytte-med-bat-sjekkliste.md\`
- [x] 21 .md files generated, 2 skipped (qr/, registrer/takk)