### PR TITLE
Empty agent-skills index until non-browser-callable paths exist

### DIFF
--- a/src/pages/.well-known/agent-skills/index.json.ts
+++ b/src/pages/.well-known/agent-skills/index.json.ts
@@ -1,28 +1,16 @@
 import type { APIRoute } from 'astro';
 
-const agentSkills = (site: URL) =>
-  JSON.stringify(
-    {
-      $schema: 'https://agentskills.io/schemas/v0.2.0/agent-skills.schema.json',
-      skills: [
-        {
-          name: 'register-turistfiskebedrift',
-          type: 'form',
-          description:
-            'Registrer turistfiskebedriften din i export.fish-appen for å rapportere fangst',
-          url: new URL('registrer', site).href,
-        },
-      ],
-    },
-    null,
-    2,
-  );
+const agentSkills = JSON.stringify(
+  {
+    $schema: 'https://agentskills.io/schemas/v0.2.0/agent-skills.schema.json',
+    skills: [],
+  },
+  null,
+  2,
+);
 
-export const GET: APIRoute = ({ site }) => {
-  if (!site) {
-    throw new Error('Astro.site is not configured. Set `site` in astro.config.mjs.');
-  }
-  return new Response(agentSkills(site), {
+export const GET: APIRoute = () => {
+  return new Response(agentSkills, {
     headers: { 'Content-Type': 'application/json; charset=utf-8' },
   });
 };


### PR DESCRIPTION
## Summary

Remove the `register-turistfiskebedrift` skill from the agent-skills index, leaving the `skills` array empty.

## Why

The previous skill declared `type: form` and pointed at the `/registrer` page. That page requires solving a Cloudflare Turnstile challenge, which only browser-capable agents (computer-use, Operator, Playwright) can do. Pure-API agents, which make up the vast majority of consumers of agent-skills indexes, cannot solve it and can therefore never invoke the skill. Advertising an uninvocable skill is misleading; no metadata is more honest than wrong metadata.

The discovery mechanism itself is unaffected: the `<link rel="agent-skills">` tag in the layout still resolves, so index-aware agents will find the endpoint and learn that there are currently zero callable skills.

## Path forward

When a proper agent-callable API endpoint exists on the backend (an API-key-authenticated path that bypasses Turnstile), or when WebMCP is broadly shipped, real skills can be added back here.

## Test plan

- [x] `npm run build` completes without errors
- [x] `dist/.well-known/agent-skills/index.json` contains `"skills": []`