### PR TITLE
SEO: erstatt tom skills-array med instruksjonell markdown-skill

### DIFF
--- a/src/pages/.well-known/agent-skills/index.json.ts
+++ b/src/pages/.well-known/agent-skills/index.json.ts
@@ -3,7 +3,15 @@ import type { APIRoute } from 'astro';
 const agentSkills = JSON.stringify(
   {
     $schema: 'https://agentskills.io/schemas/v0.2.0/agent-skills.schema.json',
-    skills: [],
+    skills: [
+      {
+        name: 'read-content-as-markdown',
+        type: 'instruction',
+        description:
+          'Read any page as clean markdown by appending .md to the URL, or follow <link rel="alternate" type="text/markdown"> in the page HTML head. Preferred for AI ingestion. (Hent enhver side som markdown ved å legge til .md i URL-en.)',
+        url: 'https://eksportfiske.no/index.md',
+      },
+    ],
   },
   null,
   2,


### PR DESCRIPTION
## Summary

- Removes the empty `skills: []` placeholder left from PR [250]
- Adds a non-callable `instruction`-type skill advertising the markdown reading pattern already published by the site

## Why the form skill was removed (context from previous PR)

The `register-turistfiskebedrift` skill used `type: form` and pointed at `/registrer`. That page requires solving a Cloudflare Turnstile challenge, which pure-API agents cannot do. Advertising an uninvocable skill is misleading.

## Why this new skill is added

The site already publishes clean markdown alternates for every page (via the `markdown-output` Astro integration from [248]). Agents that consume the skills index will learn to append `.md` to any URL, or follow `<link rel="alternate" type="text/markdown">` in the HTML head, rather than parsing raw HTML. This is a consumption pattern guide, not an invocable action.

## About the `type: "instruction"` value

The referenced schema (`https://agentskills.io/schemas/v0.2.0/agent-skills.schema.json`) returns HTTP 404. The agentskills.io specification documents only the SKILL.md file format, not the JSON discovery index format. The `type` field originates from a separate Cloudflare agent-skills-discovery RFC whose schema is currently unreachable. `instruction` is used as the closest semantic fit for a non-callable informational skill. Validators may flag it as unknown; the index remains useful regardless.

## Skill added

```json
{
  "name": "read-content-as-markdown",
  "type": "instruction",
  "description": "Read any page as clean markdown by appending .md to the URL, or follow <link rel=\"alternate\" type=\"text/markdown\"> in the page HTML head. Preferred for AI ingestion. (Hent enhver side som markdown ved å legge til .md i URL-en.)",
  "url": "https://eksportfiske.no/index.md"
}
```

## Test plan

- [x] `npm run build` completes without errors
- [x] `dist/.well-known/agent-skills/index.json` parses as valid JSON
- [x] Skill entry present with correct `name`, `type`, `description`, `url`