### PR TITLE
SEO: llms.txt og forbedret agent-oppdagelse

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -81,6 +81,7 @@ const markdownURL = new URL(_mdPathname + '.md', siteUrl).href;
     <link rel="sitemap" type="application/xml" href="/sitemap-index.xml" />
     <link rel="agent-skills" href="/.well-known/agent-skills/index.json" />
     <link rel="alternate" type="text/markdown" href={markdownURL} />
+    <meta name="ai-content-declaration" content="markdown-available, llms-txt-available, agent-skills-available" />
 
     <!-- Open Graph -->
     <meta property="og:type" content={ogType} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1063,6 +1063,9 @@ import logo from '../assets/logo.png';
       <!-- Bottom Bar -->
       <div class="border-t border-gray-800 pt-8 text-center text-sm text-gray-400">
         <p>&copy; {new Date().getFullYear()} Eksportfiske.no. Alle rettigheter reservert.</p>
+        <p class="mt-2">
+          <a href="/llms.txt" class="text-gray-600 hover:text-gray-400 transition">Maskinlesbar oversikt (llms.txt)</a>
+        </p>
       </div>
     </div>
   </footer>

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -22,20 +22,20 @@ export const GET: APIRoute = async ({ site }) => {
 
   const content = `# Eksportfiske.no
 
-> Markedsside for export.fish — en rapporteringsplattform for norske turistfiskebedrifter. Hjelper dem med å oppfylle Fiskeridirektoratets krav til fangstrapportering.
+> Marketing site for export.fish — a reporting platform for Norwegian turistfiskebedrifter (fishing tourism businesses). Helps them comply with the Norwegian Directorate of Fisheries' (Fiskeridirektoratet) catch-reporting requirements. Site content is in Norwegian.
 
-## Bloggartikler
+## Articles
 ${blogLines}
 
-## Sider
-- [Om oss](${siteBase}/om-oss/): Om export.fish og teamet bak
-- [Kontakt](${siteBase}/kontakt/): Kontaktinformasjon
-- [Registrer](${siteBase}/registrer/): Registreringsskjema for export.fish-plattformen (krever eksisterende registrering hos Fiskeridirektoratet)
+## Pages
+- [Om oss](${siteBase}/om-oss/): About the export.fish team and platform
+- [Kontakt](${siteBase}/kontakt/): Contact information
+- [Registrer](${siteBase}/registrer/): Registration form for the export.fish platform (requires the business to already be registered with Fiskeridirektoratet)
 
-## Markdown-tilgang
-Alle sider er tilgjengelige som ren markdown ved å legge til .md på URL-en (f.eks. ${siteBase}/blogg/daglig-fangstrapportering-turistfiske.md).
+## Markdown access
+Every page is available as clean markdown by appending .md to the URL (e.g. ${siteBase}/blogg/daglig-fangstrapportering-turistfiske.md).
 
-## Oppdagelse
+## Discovery
 - Sitemap: ${siteBase}/sitemap-index.xml
 - Agent Skills (Cloudflare RFC v0.2.0): ${siteBase}/.well-known/agent-skills/index.json
 - robots.txt: ${siteBase}/robots.txt

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,47 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+
+export const GET: APIRoute = async ({ site }) => {
+  if (!site) {
+    throw new Error('Astro.site is not configured. Set `site` in astro.config.mjs.');
+  }
+
+  const allPosts = await getCollection('blog');
+  const posts = allPosts.sort(
+    (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
+  );
+
+  const blogLines = posts
+    .map((post) => {
+      const url = new URL(`/blogg/${post.id}/`, site).href;
+      return `- [${post.data.title}](${url}): ${post.data.description}`;
+    })
+    .join('\n');
+
+  const siteBase = site.href.replace(/\/$/, '');
+
+  const content = `# Eksportfiske.no
+
+> Markedsside for export.fish — en rapporteringsplattform for norske turistfiskebedrifter. Hjelper dem med å oppfylle Fiskeridirektoratets krav til fangstrapportering.
+
+## Bloggartikler
+${blogLines}
+
+## Sider
+- [Om oss](${siteBase}/om-oss/): Om export.fish og teamet bak
+- [Kontakt](${siteBase}/kontakt/): Kontaktinformasjon
+- [Registrer](${siteBase}/registrer/): Registreringsskjema for export.fish-plattformen (krever eksisterende registrering hos Fiskeridirektoratet)
+
+## Markdown-tilgang
+Alle sider er tilgjengelige som ren markdown ved å legge til .md på URL-en (f.eks. ${siteBase}/blogg/daglig-fangstrapportering-turistfiske.md).
+
+## Oppdagelse
+- Sitemap: ${siteBase}/sitemap-index.xml
+- Agent Skills (Cloudflare RFC v0.2.0): ${siteBase}/.well-known/agent-skills/index.json
+- robots.txt: ${siteBase}/robots.txt
+`;
+
+  return new Response(content, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+};

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -5,6 +5,11 @@ Content-Signal: search=yes, ai-train=yes, ai-input=yes
 Allow: /
 
 Sitemap: ${new URL('sitemap-index.xml', site).href}
+
+# AI-agentressurser:
+# - llms.txt: ${new URL('llms.txt', site).href}
+# - Agent Skills: ${new URL('.well-known/agent-skills/index.json', site).href}
+# - Alle sider tilgjengelig som markdown ved å legge til .md på URL-en
 `;
 
 export const GET: APIRoute = ({ site }) => {

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -6,10 +6,10 @@ Allow: /
 
 Sitemap: ${new URL('sitemap-index.xml', site).href}
 
-# AI-agentressurser:
+# AI agent resources:
 # - llms.txt: ${new URL('llms.txt', site).href}
 # - Agent Skills: ${new URL('.well-known/agent-skills/index.json', site).href}
-# - Alle sider tilgjengelig som markdown ved å legge til .md på URL-en
+# - Every page is available as markdown by appending .md to the URL
 `;
 
 export const GET: APIRoute = ({ site }) => {


### PR DESCRIPTION
## Sammendrag

- Ny dynamisk `llms.txt` (`src/pages/llms.txt.ts`) med tittel/beskrivelse for alle bloggartikler (fra content collection), statiske sider og discovery-lenker
- `robots.txt` utvidet med kommentarblokk som peker til llms.txt, Agent Skills og markdown-konvensjonen
- `<meta name="ai-content-declaration">` lagt til i `<head>` på alle sider
- Lenke til llms.txt i bunnteksten: "Maskinlesbar oversikt (llms.txt)" (subdued, `text-gray-600`)

## Bakgrunn

AI-tilbakemelding pekte på at den gjeldende Agent Skills-tilnærmingen er for ny til å være bredt støttet. Agenter leter primært etter etablerte konvensjoner som `llms.txt` først. Denne PRen legger til de høyest-prioriterte tiltakene fra den tilbakemeldingen uten å fjerne det eksisterende.

De eksisterende `<link>`-taggene (`sitemap`, `agent-skills`, `alternate`) er bekreftet til å rendres korrekt i live HTML-en på eksportfiske.no — alle tre er til stede tidlig i `<head>`.

## Testplan

- [x] `npm run build` passerer uten advarsler
- [x] `dist/llms.txt` eksisterer med riktig format: tittel, beskrivelse, alle 13 bloggartikler, sideliste, discovery-seksjon
- [x] `dist/robots.txt` inneholder kommentarblokken med llms.txt-referanse
- [x] `dist/index.html` inneholder `<meta name="ai-content-declaration" content="markdown-available, llms-txt-available, agent-skills-available">`
- [x] Bunntekst-lenke til llms.txt rendres i `dist/index.html`
- [x] Alle tre `<link>`-tagger bekreftet i live HTML på eksportfiske.no

## Ikke i denne PRen

- **HTTP `Link` response-header** — krever Cloudflare Transform Rules eller Pages Function. Utsettes til Cloudflare Pages-migrering (issue [251]).
- **Sitemap `<xhtml:link>` alternate-oppføringer** — krever undersøkelse av `@astrojs/sitemap`-konfig for native støtte. Utsettes.