### PR TITLE
SEO: gjør llms.txt synlig for søk og agenter

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -21,7 +21,11 @@ export default defineConfig({
 
   integrations: [
     sitemap({
-      filter: (page) => !page.includes('/registrer/takk') && !page.includes('/qr')
+      filter: (page) => !page.includes('/registrer/takk') && !page.includes('/qr'),
+      customPages: [
+        'https://eksportfiske.no/llms.txt',
+        'https://eksportfiske.no/.well-known/agent-skills/index.json',
+      ],
     }),
     markdownOutput(),
   ]

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -81,6 +81,7 @@ const markdownURL = new URL(_mdPathname + '.md', siteUrl).href;
     <link rel="sitemap" type="application/xml" href="/sitemap-index.xml" />
     <link rel="agent-skills" href="/.well-known/agent-skills/index.json" />
     <link rel="alternate" type="text/markdown" href={markdownURL} />
+    <link rel="alternate" type="text/plain" href="/llms.txt" title="llms.txt — content index for AI agents" />
     <meta name="ai-content-declaration" content="markdown-available, llms-txt-available, agent-skills-available" />
 
     <!-- Open Graph -->

--- a/src/pages/.well-known/agent-skills/index.json.ts
+++ b/src/pages/.well-known/agent-skills/index.json.ts
@@ -11,6 +11,13 @@ const agentSkills = JSON.stringify(
           'Read any page as clean markdown by appending .md to the URL, or follow <link rel="alternate" type="text/markdown"> in the page HTML head. Preferred for AI ingestion. (Hent enhver side som markdown ved å legge til .md i URL-en.)',
         url: 'https://eksportfiske.no/index.md',
       },
+      {
+        name: 'site-content-index',
+        type: 'instruction',
+        description:
+          'Full site content index following the llms.txt convention (https://llmstxt.org). Lists all articles and pages with descriptions. Useful as a starting point for understanding the site.',
+        url: 'https://eksportfiske.no/llms.txt',
+      },
     ],
   },
   null,

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -10,6 +10,7 @@ Sitemap: ${new URL('sitemap-index.xml', site).href}
 # - llms.txt: ${new URL('llms.txt', site).href}
 # - Agent Skills: ${new URL('.well-known/agent-skills/index.json', site).href}
 # - Every page is available as markdown by appending .md to the URL
+# llms.txt convention reference: https://llmstxt.org
 `;
 
 export const GET: APIRoute = ({ site }) => {


### PR DESCRIPTION
## Summary

- **sitemap.xml**: Legger til `/llms.txt` og `/.well-known/agent-skills/index.json` som `customPages` i `@astrojs/sitemap`. Begge dukker nå opp i `sitemap-0.xml`, som betyr at Google/Bing indekserer dem og `site:eksportfiske.no llms.txt`-søk vil returnere dem.
- **HTML head**: Ny `<link rel="alternate" type="text/plain" href="/llms.txt" title="llms.txt — content index for AI agents">` i `Layout.astro`. Agenter som parser `<head>` uten å bruke søkemotorer finner nå llms.txt direkte fra homepage-HTML.
- **agent-skills index**: Andre skill-entry `site-content-index` lagt til. Agenter som laster `/.well-known/agent-skills/index.json` ser nå eksplisitt at det finnes en innholdsindeks på `/llms.txt`.
- **robots.txt**: Ekstra kommentarlinje `# llms.txt convention reference: https://llmstxt.org` — nysgjerrige agenter som leser kommentarene kan følge spec-referansen.

## Why

En AI ga tilbakemelding om tre discoverability-hull:
1. Den sjekket bare homepage, visste ikke å prøve `/llms.txt` direkte.
2. `site:eksportfiske.no llms` returnerte ingen resultater fordi søkemotorer ikke hadde indeksert llms.txt.
3. WebFetch-verktøy nekter av og til URL-er som ikke har dukket opp i søkeresultater eller blitt lim inn av bruker.

Disse fikser alle tre kanalene agenter bruker for oppdagelse: HTML head-parsing, sitemap-konsultering, og well-known discovery.

## What's not in this PR

- **HTTP `Link`-headere** — avhenger av issue [251] (Cloudflare Pages-migrasjon). Kan legges til der.
- **`llms-full.txt`** (full sammenslått innhold) — trolig overkill for en marketing-site; kan legges til ved etterspørsel.
- **Per-URL `<xhtml:link rel="alternate">` i sitemap** — `@astrojs/sitemap` støtter ikke dette uten custom serializer. Utsatt.

## Test plan

- [x] `bun run build` / `npx astro build` kompilerer uten feil
- [x] `dist/sitemap-0.xml` inneholder `https://eksportfiske.no/llms.txt`
- [x] `dist/sitemap-0.xml` inneholder `https://eksportfiske.no/.well-known/agent-skills/index.json`
- [x] `dist/index.html` har `<link rel="alternate" type="text/plain" href="/llms.txt" ...>` i head
- [x] `dist/.well-known/agent-skills/index.json` har 2 skills (read-content-as-markdown + site-content-index)
- [x] `dist/robots.txt` har `# llms.txt convention reference: https://llmstxt.org`