### PR TITLE
Add descriptive alt to hero image

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,7 +29,7 @@ import logo from '../assets/logo.png';
   <section class="relative pt-52 pb-32 md:pb-40 text-white overflow-hidden" aria-labelledby="hero-heading">
     <!-- Background Image -->
     <div class="absolute inset-0 hero-bg-fade" aria-hidden="true">
-      <Image src={heroBg} alt="" class="w-full h-full object-cover" widths={[640, 1024, 1280, 1920]} sizes="100vw" loading="eager" fetchpriority="high" quality={75} />
+      <Image src={heroBg} alt="Norsk turistfiskebedrift ved fjorden, klar for en ny sesong med fangstrapportering" class="w-full h-full object-cover" widths={[640, 1024, 1280, 1920]} sizes="100vw" loading="eager" fetchpriority="high" quality={75} />
       <div class="absolute inset-0 bg-gradient-to-br from-blue-400/75 via-blue-500/80 to-blue-600/85"></div>
     </div>
 


### PR DESCRIPTION
## Summary

- Hero `<img>` on the homepage had an empty `alt=""`, flagged by Bing Webmaster Tools as a guideline violation
- Added a descriptive Norwegian alt: "Norsk turistfiskebedrift ved fjorden, klar for en ny sesong med fangstrapportering"
- Matches the style of existing feature image alts on the page; build verified clean