### PR TITLE
Use lang="nb" instead of macrolanguage "no"

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -58,7 +58,7 @@ const markdownURL = new URL(_mdPathname + '.md', siteUrl).href;
 ---
 
 <!doctype html>
-<html lang="no">
+<html lang="nb">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />


### PR DESCRIPTION
## Summary

- Changes `<html lang="no">` to `<html lang="nb">` in `src/layouts/Layout.astro`
- `nb` (Norwegian Bokmål) is the correct BCP 47 subtag; `no` is a macrolanguage tag that Bing Webmaster Guidelines flag as imprecise
- Aligns the HTML `lang` attribute with the existing `og:locale="nb_NO"` meta tag — both now consistently signal Bokmål

## Background

Bing's webmaster guidelines recommend using the most specific BCP 47 language tag available. The site already uses `og:locale=nb_NO`, so this change removes the inconsistency between the two signals. One file changed, one line changed.

## Test plan

- [x] `npm run build` completes without errors (26 pages, 86 images)
- [x] `dist/index.html` contains `<html lang="nb">` (verified via grep)