### PR TITLE
Resolve duplicate URL between /registrer and /registrering

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -21,7 +21,10 @@ export default defineConfig({
 
   integrations: [
     sitemap({
-      filter: (page) => !page.includes('/registrer/takk') && !page.includes('/qr'),
+      filter: (page) =>
+        !page.includes('/registrer/takk') &&
+        !page.includes('/registrer/ny-kunde') &&
+        !page.includes('/qr'),
       customPages: [
         'https://eksportfiske.no/llms.txt',
         'https://eksportfiske.no/.well-known/agent-skills/index.json',

--- a/src/pages/registrer/index.astro
+++ b/src/pages/registrer/index.astro
@@ -7,8 +7,8 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
 ---
 
 <Layout
-  title="Kom i gang med export.fish"
-  description="Meld din interesse for export.fish – digital fangstrapportering for turistfiskebedrifter. Vi tar kontakt og hjelper deg i gang."
+  title="Prøv export.fish gratis – digital fangstrapportering"
+  description="Start din gratis prøveperiode med export.fish. Fyll ut skjemaet, så tar vi kontakt og hjelper deg i gang med godkjent fangstrapportering for turistfiskebedriften din."
 >
   <!-- Hero Section -->
   <section class="pt-52 pb-16 bg-gradient-to-br from-blue-50 to-blue-100">

--- a/src/pages/registrering.astro
+++ b/src/pages/registrering.astro
@@ -3,8 +3,8 @@ import Layout from '../layouts/Layout.astro';
 ---
 
 <Layout
-  title="Registrering som turistfiskebedrift | Eksportfiske.no"
-  description="Sjekk om du må registrere deg som turistfiskebedrift. Veileder for registrering hos Fiskeridirektoratet og krav til fangstrapportering."
+  title="Turistfiskebedrift? Krav og veileder for Fiskeridirektoratet-registrering"
+  description="Finn ut om du er pliktig eller kan registrere deg frivillig som turistfiskebedrift hos Fiskeridirektoratet. Sjekkliste, konsekvenser og steg-for-steg-veileder."
 >
 
   <!-- Registration Requirements Quiz Section -->


### PR DESCRIPTION
## What changed and why

Bing's webmaster audit flagged `/registrer/`, `/registrer/ny-kunde/`, and `/registrering/` as potential duplicate-content URLs competing for the same \"register\" intent.

### Investigation findings

After reading all three page sources:

| URL | Purpose | Funnel position |
|-----|---------|-----------------|
| `/registrering/` | Educational guide: quiz to determine if you must register with Fiskeridirektoratet, consequences, 5-step how-to | Top of funnel (informational) |
| `/registrer/` | Lead capture: interest form submitting to `export.fish/v1/leads/register` | Mid/bottom funnel (conversion) |
| `/registrer/ny-kunde/` | Full business registration form: org number, subdomain, contacts, terms | Bottom funnel (already `noindex`) |

### Decision: Strategy (b) - pages serve genuinely distinct purposes

No redirect needed. The pages are genuinely different and both deserve to be indexed, but their `<title>` and `<meta description>` were too similar and both used the word "registrering" prominently, giving search engines an unclear signal.

### Changes made

1. **`/registrering/`** - New title: "Turistfiskebedrift? Krav og veileder for Fiskeridirektoratet-registrering" — clearly signals informational/educational intent, anchored to Fiskeridirektoratet
2. **`/registrer/`** - New title: "Prøv export.fish gratis – digital fangstrapportering" — clearly signals product trial/signup intent, no overlap with the guide page
3. **`astro.config.mjs`** - Added `/registrer/ny-kunde/` to the sitemap filter exclusions — this page already has `noindex` set via the Layout prop, so excluding it from the sitemap makes the signal consistent

Canonical tags are auto-generated by Layout.astro from `Astro.url.pathname`, so both indexed pages already had correct self-referencing canonicals before this change.

### Validation

Build passes cleanly. Sitemap output confirmed: `/registrer/` and `/registrering/` present, `/registrer/ny-kunde/` absent.

## Test plan

- [ ] Verify `dist/sitemap-0.xml` contains `/registrer/` and `/registrering/` but not `/registrer/ny-kunde/`
- [ ] Verify `dist/registrer/index.html` has `<link rel="canonical" href="https://eksportfiske.no/registrer/">`
- [ ] Verify `dist/registrering/index.html` has `<link rel="canonical" href="https://eksportfiske.no/registrering/">`
- [ ] Verify `dist/registrer/ny-kunde/index.html` has `<meta name="robots" content="noindex, nofollow">` (unchanged)
- [ ] Resubmit sitemap in Bing Webmaster Tools after merge