### PR TITLE
Add aria-labels to icon-only controls

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -329,19 +329,19 @@ const markdownURL = new URL(_mdPathname + '.md', siteUrl).href;
   <body class="bg-gray-50 text-gray-900">
     <!-- Fixed Navigation -->
     <header class="fixed top-0 w-full bg-white/90 backdrop-blur-sm border-b border-gray-200 z-50">
-      <nav class="container mx-auto px-4 py-4 flex justify-between items-center">
+      <nav class="container mx-auto px-4 py-4 flex justify-between items-center" aria-label="Hovedmeny">
         <a href="/" class="flex items-center gap-3 group">
           <Image src={logo} alt="export.fish logo" width={80} height={80} densities={[1, 2]} class="h-16 w-16 md:h-20 md:w-20 transition-transform group-hover:scale-110" />
           <span class="text-2xl md:text-3xl font-bold text-primary">Eksportfiske</span>
         </a>
         <!-- Mobile menu (hamburger) -->
         <details id="mobile-menu" class="md:hidden relative">
-          <summary class="cursor-pointer p-2 list-none flex items-center justify-center">
-            <svg class="w-6 h-6 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <summary class="cursor-pointer p-2 list-none flex items-center justify-center" aria-label="Åpne meny">
+            <svg class="w-6 h-6 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
             </svg>
           </summary>
-          <nav class="absolute right-0 top-full mt-2 flex flex-col p-4 bg-white shadow-lg rounded-lg border border-gray-200 min-w-[200px] divide-y divide-gray-200">
+          <nav class="absolute right-0 top-full mt-2 flex flex-col p-4 bg-white shadow-lg rounded-lg border border-gray-200 min-w-[200px] divide-y divide-gray-200" aria-label="Mobilmeny">
             <a href="/#hvordan-virker-det" class="text-gray-600 hover:text-primary transition py-3 px-3 hover:bg-gray-50 rounded">Hvordan virker det?</a>
             <a href="/registrering" class="text-gray-600 hover:text-primary transition py-3 px-3 hover:bg-gray-50 rounded">Turistfiskebedrift?</a>
             <a href="/om-oss" class="text-gray-600 hover:text-primary transition py-3 px-3 hover:bg-gray-50 rounded">Om oss</a>


### PR DESCRIPTION
## Summary

- Add `aria-label=\"Åpne meny\"` to the hamburger `<summary>` (SVG-only, no visible text)
- Add `aria-label=\"Hovedmeny\"` to the site-header `<nav>` wrapper
- Add `aria-label=\"Mobilmeny\"` to the mobile dropdown `<nav>`, distinguishing it from the outer nav
- Add `aria-hidden=\"true\"` to the hamburger SVG so screen readers use the label, not the path data

All changes are in `/src/layouts/Layout.astro` only. No restyling or component refactoring.

Build verified: `astro build` passes and all three aria-labels appear in rendered `dist/index.html`.

## Scope guard

This is an aria-label and labelling pass only. The following were noted but left for follow-up:

- **Focus styles**: desktop nav links and the hamburger button rely on browser defaults; a custom visible focus ring (`:focus-visible`) would improve keyboard navigation
- **Color contrast**: some `text-gray-400` on dark footer backgrounds may be borderline — worth a dedicated contrast audit pass