### PR TITLE
Legg til <lastmod> på blogg-URLer i sitemap

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full history needed so the sitemap build can compute <lastmod>
+          # via `git log -1 --format=%cI -- <file>` for each page.
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,14 +1,40 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import tailwindcss from '@tailwindcss/vite';
 
 import sitemap from '@astrojs/sitemap';
 import markdownOutput from './src/integrations/markdown-output.ts';
 
+const SITE_URL = 'https://eksportfiske.no';
+
+function buildBlogLastmodMap() {
+  const map = new Map();
+  const blogDir = './src/content/blog';
+  const skip = new Set(['REVIEW_GUIDELINES.md', 'HERO_IMAGE_GUIDELINES.md']);
+
+  for (const file of readdirSync(blogDir)) {
+    if (!file.endsWith('.md') || skip.has(file)) continue;
+    const fm = readFileSync(join(blogDir, file), 'utf-8').match(/^---\n([\s\S]*?)\n---/)?.[1];
+    if (!fm) continue;
+    const pubDate = fm.match(/^pubDate:\s*(.+)$/m)?.[1]?.trim();
+    const updatedDate = fm.match(/^updatedDate:\s*(.+)$/m)?.[1]?.trim();
+    const lastmod = updatedDate || pubDate;
+    if (!lastmod) continue;
+    const slug = file.replace(/\.md$/, '');
+    map.set(`${SITE_URL}/blogg/${slug}/`, new Date(lastmod).toISOString());
+  }
+
+  return map;
+}
+
+const blogLastmod = buildBlogLastmodMap();
+
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://eksportfiske.no',
+  site: SITE_URL,
   base: '',
 
   build: {
@@ -26,9 +52,16 @@ export default defineConfig({
         !page.includes('/registrer/ny-kunde') &&
         !page.includes('/qr'),
       customPages: [
-        'https://eksportfiske.no/llms.txt',
-        'https://eksportfiske.no/.well-known/agent-skills/index.json',
+        `${SITE_URL}/llms.txt`,
+        `${SITE_URL}/.well-known/agent-skills/index.json`,
       ],
+      serialize(item) {
+        const lastmod = blogLastmod.get(item.url);
+        if (lastmod) {
+          item.lastmod = lastmod;
+        }
+        return item;
+      },
     }),
     markdownOutput(),
   ]

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
-import { readdirSync, readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import tailwindcss from '@tailwindcss/vite';
@@ -9,15 +10,44 @@ import sitemap from '@astrojs/sitemap';
 import markdownOutput from './src/integrations/markdown-output.ts';
 
 const SITE_URL = 'https://eksportfiske.no';
+const PAGES_DIR = './src/pages';
+const BLOG_DIR = './src/content/blog';
+
+function gitLastCommitISO(filePath) {
+  try {
+    const out = execFileSync('git', ['log', '-1', '--format=%cI', '--', filePath], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    return out ? new Date(out).toISOString() : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolvePageSourceFile(pathname) {
+  // pathname like "/", "/kontakt/", "/registrer/", "/llms.txt"
+  const trimmed = pathname.replace(/^\/+/, '').replace(/\/+$/, '');
+  if (trimmed === '') return join(PAGES_DIR, 'index.astro');
+
+  const candidates = [
+    join(PAGES_DIR, `${trimmed}.astro`),
+    join(PAGES_DIR, trimmed, 'index.astro'),
+    join(PAGES_DIR, `${trimmed}.ts`),
+    join(PAGES_DIR, `${trimmed}.js`),
+    join(PAGES_DIR, `${trimmed}.md`),
+  ];
+  for (const c of candidates) if (existsSync(c)) return c;
+  return null;
+}
 
 function buildBlogLastmodMap() {
   const map = new Map();
-  const blogDir = './src/content/blog';
   const skip = new Set(['REVIEW_GUIDELINES.md', 'HERO_IMAGE_GUIDELINES.md']);
 
-  for (const file of readdirSync(blogDir)) {
+  for (const file of readdirSync(BLOG_DIR)) {
     if (!file.endsWith('.md') || skip.has(file)) continue;
-    const fm = readFileSync(join(blogDir, file), 'utf-8').match(/^---\n([\s\S]*?)\n---/)?.[1];
+    const fm = readFileSync(join(BLOG_DIR, file), 'utf-8').match(/^---\n([\s\S]*?)\n---/)?.[1];
     if (!fm) continue;
     const pubDate = fm.match(/^pubDate:\s*(.+)$/m)?.[1]?.trim();
     const updatedDate = fm.match(/^updatedDate:\s*(.+)$/m)?.[1]?.trim();
@@ -31,6 +61,18 @@ function buildBlogLastmodMap() {
 }
 
 const blogLastmod = buildBlogLastmodMap();
+
+function lastmodFor(url) {
+  // Blog posts: prefer pubDate/updatedDate over git mtime — it's the
+  // authoritative "this is when the article was published/edited" signal.
+  const fromBlog = blogLastmod.get(url);
+  if (fromBlog) return fromBlog;
+
+  const pathname = new URL(url).pathname;
+  const sourceFile = resolvePageSourceFile(pathname);
+  if (!sourceFile) return null;
+  return gitLastCommitISO(sourceFile);
+}
 
 // https://astro.build/config
 export default defineConfig({
@@ -56,7 +98,7 @@ export default defineConfig({
         `${SITE_URL}/.well-known/agent-skills/index.json`,
       ],
       serialize(item) {
-        const lastmod = blogLastmod.get(item.url);
+        const lastmod = lastmodFor(item.url);
         if (lastmod) {
           item.lastmod = lastmod;
         }

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -21,6 +21,7 @@ const blogCollection = defineCollection({
       description: z.string(),
       guid: z.string(),
       pubDate: z.coerce.date(),
+      updatedDate: z.coerce.date().optional(),
       author: z.string().default('Kim Eik'),
       image: z
         .object({


### PR DESCRIPTION
## Summary
- **Blog posts** get `<lastmod>` from frontmatter `pubDate` (or new optional `updatedDate` if set).
- **Static pages and custom-pages** get `<lastmod>` from `git log -1 --format=%cI -- <file>` on the source file (e.g. `src/pages/kontakt.astro`, `src/pages/llms.txt.ts`).
- CI workflow updated with `fetch-depth: 0` so the deploy build has full git history available for the lookups.

## What the sitemap looks like now
Every URL gets a `<lastmod>` in ISO 8601:

```xml
<url><loc>https://eksportfiske.no/</loc><lastmod>2026-05-10T15:41:22.000Z</lastmod></url>
<url><loc>https://eksportfiske.no/blogg/tolletaten-grense-fisk-bot-unnga/</loc><lastmod>2026-05-09T08:00:00.000Z</lastmod></url>
<url><loc>https://eksportfiske.no/kontakt/</loc><lastmod>2026-05-07T12:02:48.000Z</lastmod></url>
<url><loc>https://eksportfiske.no/llms.txt</loc><lastmod>2026-05-07T22:08:27.000Z</lastmod></url>
```

## Why git log over file mtime
`git checkout` doesn't preserve mtime, so `fs.statSync(...).mtime` would resolve to "the moment CI cloned the repo" for every file (essentially `now`). `git log -1 -- <file>` returns the actual last commit that touched that file, which is the honest "last edited" signal.

## Schema change
Added optional `updatedDate` to the blog content collection. When set, it overrides `pubDate` for `<lastmod>`. Lets us bump the lastmod on a corrected article without rewriting publish history.

## Test plan
- [x] `npm run build` passes
- [x] `dist/sitemap-0.xml` has `<lastmod>` on every URL (blog, static, llms.txt, agent-skills)
- [x] Blog dates come from `pubDate`, not git
- [x] Static pages show last-commit dates that match `git log -1 -- src/pages/<file>`
- [ ] After merge: verify GitHub Pages deploy succeeds with `fetch-depth: 0`
- [ ] After merge: confirm Google Search Console picks up `<lastmod>` on next sitemap fetch

## Followup ideas
- Bump `updatedDate` on the toll article (PR #224) to surface the factual corrections to search engines
- Consider whether `Layout.astro` / shared component edits should bump every page's `<lastmod>` (currently they don't — only direct page edits count)