### PR TITLE
Add BreadcrumbList and ItemList structured data

### DIFF
--- a/src/pages/blogg/[...slug].astro
+++ b/src/pages/blogg/[...slug].astro
@@ -55,6 +55,16 @@ const jsonLd = {
       }
     : {}),
 };
+
+const breadcrumbLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Hjem', item: `${siteUrl}/` },
+    { '@type': 'ListItem', position: 2, name: 'Blogg', item: `${siteUrl}/blogg/` },
+    { '@type': 'ListItem', position: 3, name: entry.data.title, item: canonicalURL },
+  ],
+};
 ---
 
 <Layout
@@ -67,6 +77,7 @@ const jsonLd = {
 >
   <Fragment slot="head">
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+    <script type="application/ld+json" set:html={JSON.stringify(breadcrumbLd)} />
   </Fragment>
 
   <article class="pt-44 pb-16 bg-white">

--- a/src/pages/blogg/index.astro
+++ b/src/pages/blogg/index.astro
@@ -15,12 +15,27 @@ function formatDate(date: Date): string {
     year: 'numeric',
   });
 }
+
+const siteUrl = 'https://eksportfiske.no';
+
+const itemListLd = {
+  '@context': 'https://schema.org',
+  '@type': 'ItemList',
+  itemListElement: posts.map((post, index) => ({
+    '@type': 'ListItem',
+    position: index + 1,
+    url: `${siteUrl}/blogg/${post.id}/`,
+  })),
+};
 ---
 
 <Layout
   title="Blogg | Eksportfiske.no"
   description="Artikler om turistfiske, registrering, fangstrapportering og regelverk for turistfiskebedrifter i Norge."
 >
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={JSON.stringify(itemListLd)} />
+  </Fragment>
   <section class="pt-44 pb-16 bg-white">
     <div class="max-w-4xl mx-auto px-4">
       <h1 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">Blogg</h1>


### PR DESCRIPTION
## Summary

Implements two structured data blocks surfaced by a Bing webmaster-guidelines audit (10 May 2026):

- **BreadcrumbList** on every blog post (`/blogg/[...slug].astro`): three-level path Hjem > Blogg > article title, emitted alongside the existing Article schema via a second `<script type="application/ld+json">` block in the `head` slot.
- **ItemList** on the blog index (`/blogg/index.astro`): one `ListItem` per post, ordered newest-first to match the rendered card order, with absolute canonical URLs.

Both schemas use standard schema.org property names (`name`, `url`, `position`), 1-indexed contiguous positions, and absolute `https://eksportfiske.no/` URLs.

## Test plan

- [x] `npm run build` completes without errors (25 pages built)
- [x] `dist/blogg/index.html` contains `"@type":"ItemList"` with absolute URLs
- [x] `dist/blogg/tolletaten-grense-fisk-bot-unnga/index.html` contains `"@type":"BreadcrumbList"` with correct three-level path
- [ ] Validate with Google Rich Results Test / Bing Markup Validator after deploy