### PR TITLE
Fix: remove broken internal blog links

### DIFF
--- a/src/content/blog/fritidsfiske-sportsfiske-turistfiske-forskjell.md
+++ b/src/content/blog/fritidsfiske-sportsfiske-turistfiske-forskjell.md
@@ -89,7 +89,7 @@ En vanlig misforståelse er at det er turistens ansvar å holde seg innenfor reg
 
 Hvis gjesten forsøker å ta med fisk uten gyldig dokumentasjon, er det gjesten som møter Tolletaten ved grensen. Men det er du som utleier som har satt gjesten i den situasjonen — enten fordi du ikke var registrert, eller fordi dokumentasjonen ikke var på plass. Det er derfor koblingen mellom begrepsforståelse og faktisk drift er viktigere enn det virker ved første øyekast.
 
-Et bærekraftig og gjestevennlig fisketilbud forutsetter at regelverket er avklart fra din side før turistsesongen starter. Les mer om [bærekraftig turistfiske og fang-og-slipp-praksis](/blogg/baerekraftig-turistfiske-fang-slipp/) og hvordan norske [fiskedestinasjoner skiller seg fra hverandre](/blogg/fiskedestinasjoner-norge-regional/).
+Et bærekraftig og gjestevennlig fisketilbud forutsetter at regelverket er avklart fra din side før turistsesongen starter.
 
 ---
 

--- a/src/content/blog/leie-hytte-med-bat-sjekkliste.md
+++ b/src/content/blog/leie-hytte-med-bat-sjekkliste.md
@@ -75,7 +75,7 @@ Utførselsdokumentet er ikke noe du bare skriver ut på slutten. Grunnlaget er a
 
 Dette er punktet flest undervurderer. Informasjon som virker åpenbar for deg, er ikke åpenbar for en turist som ankommer sliten etter mange timers reise og er ivrig etter å komme seg på sjøen.
 
-- [ ] Er sjøvettsreglene tilgjengelig på et språk gjestene faktisk leser? Tysk er viktig for mange norske fiskehytter — se hva vi har laget for [sjøvettsregler på tysk og engelsk](/blogg/sjovettregler-tysk-engelsk-gjester/).
+- [ ] Er sjøvettsreglene tilgjengelig på et språk gjestene faktisk leser? Tysk er viktig for mange norske fiskehytter.
 - [ ] Har du informert om [fiskeregler og kvoter](/blogg/fritidsfiske-sportsfiske-turistfiske-forskjell/) — hva som er lov å fiske, minstemål og fredningstider?
 - [ ] Vet gjestene at de skal [rapportere fangst daglig](/blogg/daglig-fangstrapportering-turistfiske/) — også dager uten fangst?
 - [ ] Er det tydelig hvem de kontakter ved problemer med båten?
@@ -96,8 +96,6 @@ En vanlig innboforsikring eller hytteforsikring dekker normalt ikke utleievirkso
 
 Forskjellen mellom kasko og ansvar er vesentlig: ansvarsforsikring dekker skade på andre, kaskoforsikring dekker skade på din egen båt. Hvis en gjest kjører på en stein, vil du gjerne ha kasko. Mange tror de har det — men utleieklausuler kan sette forsikringen ut av spill. Sjekk dette skriftlig, ikke muntlig.
 
-Se mer om [forsikring for utleiebåt og fiskehytte](/blogg/forsikring-utleiebat-fiskehytte/) for en grundigere gjennomgang av hva du bør be om fra forsikringsselskapet.
-
 ---
 
 ## 6. Skatt og MVA
@@ -115,8 +113,6 @@ MVA-reglene er mer kompliserte. Etter MVA-loven § 2-1 er omsetning av utleietje
 - [ ] Er fakturering og bokføring i tråd med kravene dersom du er MVA-registrert?
 
 Skatteetaten har god veiledning om utleie av fritidseiendom. Vi anbefaler å lese den og eventuelt konsultere en regnskapsfører før du begynner å ta inn gjester — ikke etter.
-
-Se mer om [skatt ved utleie av fiskehytte](/blogg/skatt-utleie-fiskehytte/).
 
 ---
 

--- a/src/content/blog/slik-registrerer-du-turistfiskebedrift.md
+++ b/src/content/blog/slik-registrerer-du-turistfiskebedrift.md
@@ -91,7 +91,7 @@ Mange bruker unødvendig lang tid fordi de ikke har all informasjon tilgjengelig
 
 Har du alt dette klart, er selve søknaden grei å fylle ut. Det tar som regel ikke mer enn 15–20 minutter.
 
-Sjekkliste for utleiere som vil gjøre alt riktig fra start finner du i [leie-hytte-med-båt-sjekklisten](/blogg/leie-hytte-med-bat-sjekkliste/). Har du spørsmål om skatt og inntektsføring av utleieinntektene, er [skatt på utleie av fiskehytte](/blogg/skatt-utleie-fiskehytte/) et godt utgangspunkt. Utførsel av fisk for gjestene forutsetter at du også kjenner kravene til [utførselsdokumentasjon](/blogg/utforselsdokument-fisk-krav/). Familier med barn reiser egne spørsmål, se gjennomgangen av [aldersgrense i turistfiske](/blogg/aldersgrense-turistfiske-12-ar/).
+Sjekkliste for utleiere som vil gjøre alt riktig fra start finner du i [leie-hytte-med-båt-sjekklisten](/blogg/leie-hytte-med-bat-sjekkliste/). Utførsel av fisk for gjestene forutsetter at du også kjenner kravene til [utførselsdokumentasjon](/blogg/utforselsdokument-fisk-krav/). Familier med barn reiser egne spørsmål, se gjennomgangen av [aldersgrense i turistfiske](/blogg/aldersgrense-turistfiske-12-ar/).
 
 Vi mener at registreringen er det enkle trinnet. Det er det som kommer etterpå, rutinene, rapporteringen og dokumentasjonen, som avgjør om driften faktisk holder mål i sesongen. Men du må ha registreringen på plass for å komme i gang. Og du kan ikke vente til første gjest banker på døra.
 

--- a/src/content/blog/tolletaten-grense-fisk-bot-unnga.md
+++ b/src/content/blog/tolletaten-grense-fisk-bot-unnga.md
@@ -43,7 +43,7 @@ De fleste overskridelsene skyldes ikke bevisst smugling, men misforståelser og 
 
 **De fordeler fisken mellom biler eller reisefølge uten at dokumentasjonen stemmer.** Å flytte fisk fra en bil til en annen for å skjule mengden er en klassisk feil — og det er ulovlig uavhengig av om den samlede mengden per person er innenfor kvoten.
 
-**De tar med troféfisk.** Troféfisken ble fjernet som unntak fra regelverket allerede i 2018, da Nærings- og fiskeridepartementet fastsatte ny forskrift om turistfiskevirksomheter. [Trofékveite og andre store eksemplarer regnes inn i kvoten](/blogg/trofefisk-fjernet-turistfiske/) på lik linje med annen fisk, men mange gjester tror fortsatt at de kan ta med én stor fisk i tillegg.
+**De tar med troféfisk.** Troféfisken ble fjernet som unntak fra regelverket allerede i 2018, da Nærings- og fiskeridepartementet fastsatte ny forskrift om turistfiskevirksomheter. Trofékveite og andre store eksemplarer regnes inn i kvoten på lik linje med annen fisk, men mange gjester tror fortsatt at de kan ta med én stor fisk i tillegg.
 
 ## Ditt ansvar som utleier — medvirkning er ikke en hypotetisk risiko
 
@@ -67,7 +67,7 @@ For å unngå den situasjonen trenger du en rapporteringsrutine som fungerer lø
 
 ## For tyske og engelskspråklige gjester
 
-En stor andel av gjestene ved norske turistfiskebedrifter kommer fra tyskspråklige land og er ikke kjent med norsk tollpraksis. Mange tror at det er nok å "bare" ha fisket lovlig, uten å forstå dokumentasjonskravene. Orienter gjestene på deres eget språk om de tre nøkkelpunktene: kvoten, dokumentet, og veiingen. [Sjøvettsregler og avreiseinformasjon på tysk og engelsk](/blogg/sjovettregler-tysk-engelsk-gjester/) hjelper deg å nå dem uten at du må lage alt fra bunnen.
+En stor andel av gjestene ved norske turistfiskebedrifter kommer fra tyskspråklige land og er ikke kjent med norsk tollpraksis. Mange tror at det er nok å "bare" ha fisket lovlig, uten å forstå dokumentasjonskravene. Orienter gjestene på deres eget språk om de tre nøkkelpunktene: kvoten, dokumentet, og veiingen.
 
 ## Det store bildet
 


### PR DESCRIPTION
8 internal blog links were confirmed as 404s by Bing audit. This PR removes them from master prose, keeping text readable while the target articles are still pending merge.

Each owning PR will restore its back-link(s) on merge via a dedicated commit already pushed to its branch.

| # | Source file | Removed link slug | Owning PR |
|---|---|---|---|
| 1 | fritidsfiske-sportsfiske-turistfiske-forskjell.md | baerekraftig-turistfiske-fang-slipp | [PR 237] |
| 2 | fritidsfiske-sportsfiske-turistfiske-forskjell.md | fiskedestinasjoner-norge-regional | [PR 241] |
| 3 | leie-hytte-med-bat-sjekkliste.md | sjovettregler-tysk-engelsk-gjester | [PR 231] |
| 4 | leie-hytte-med-bat-sjekkliste.md | forsikring-utleiebat-fiskehytte | [PR 229] |
| 5 | leie-hytte-med-bat-sjekkliste.md | skatt-utleie-fiskehytte | [PR 225] |
| 6 | slik-registrerer-du-turistfiskebedrift.md | skatt-utleie-fiskehytte | [PR 225] |
| 7 | tolletaten-grense-fisk-bot-unnga.md | trofefisk-fjernet-turistfiske | [PR 222] |
| 8 | tolletaten-grense-fisk-bot-unnga.md | sjovettregler-tysk-engelsk-gjester | [PR 231] |

Build validated locally before push.