### PR TITLE
Legg til H1 og kort intro på /registrering/

### DIFF
--- a/src/pages/registrering.astro
+++ b/src/pages/registrering.astro
@@ -10,6 +10,12 @@ import Layout from '../layouts/Layout.astro';
   <!-- Registration Requirements Quiz Section -->
   <section id="skal-jeg-registrere" class="pt-44 pb-16 px-4 bg-gradient-to-br from-blue-50 to-slate-50">
     <div class="max-w-6xl mx-auto px-4">
+      <div class="text-center mb-10">
+        <h1 class="text-4xl md:text-5xl font-bold text-gray-900 mb-4">Krav og veileder for turistfiskebedrift</h1>
+        <p class="text-lg text-gray-600 max-w-2xl mx-auto">
+          Sjekk om utleien din krever registrering hos Fiskeridirektoratet, sammenlign privat utleie med registrert bedrift, og følg veilederen som tar deg gjennom de fem stegene.
+        </p>
+      </div>
       <div id="quiz-card" class="bg-white rounded-2xl shadow-xl overflow-hidden border border-blue-200">
         <!-- Dynamic Header -->
         <div id="quiz-header" class="bg-gradient-to-r from-blue-600 to-blue-700 px-8 py-6 transition-all duration-300">

--- a/src/pages/registrering.astro
+++ b/src/pages/registrering.astro
@@ -11,7 +11,7 @@ import Layout from '../layouts/Layout.astro';
   <section id="skal-jeg-registrere" class="pt-44 pb-16 px-4 bg-gradient-to-br from-blue-50 to-slate-50">
     <div class="max-w-6xl mx-auto px-4">
       <div class="text-center mb-10">
-        <h1 class="text-4xl md:text-5xl font-bold text-gray-900 mb-4">Krav og veileder for turistfiskebedrift</h1>
+        <h1 class="text-4xl md:text-5xl font-bold text-gray-900 mb-4">Trenger du å registrere turistfiskebedrift?</h1>
         <p class="text-lg text-gray-600 max-w-2xl mx-auto">
           Sjekk om utleien din krever registrering hos Fiskeridirektoratet, sammenlign privat utleie med registrert bedrift, og følg veilederen som tar deg gjennom de fem stegene.
         </p>


### PR DESCRIPTION
## Bakgrunn

`/registrering/` mangler `<h1>`-tag, både SEO- og a11y-mangel. Den eneste H2 på toppen er kvissens dynamiske heading som endrer tekst basert på svar, og er derfor uegnet som stabil page heading.

## Endring

Lagt til en stabil intro-blokk øverst i kvisseksjonen:

\`\`\`html
<h1>Krav og veileder for turistfiskebedrift</h1>
<p>Sjekk om utleien din krever registrering hos Fiskeridirektoratet, sammenlign privat utleie med registrert bedrift, og følg veilederen som tar deg gjennom de fem stegene.</p>
\`\`\`

- H1 er statisk og keyword-relevant (matcher tittelen "Krav og veileder: registrer turistfiskebedrift")
- Beskrivelsen oppsummerer sidens tre hoveddeler (sjekkliste, sammenligning, veileder)
- Kvisskortets dynamiske heading beholdt som H2 (lar JS-en fortsette å oppdatere den uten å forstyrre page heading-semantikken)

## Verifisert

- `npm run build`: 25 sider, ingen feil
- `dist/registrering/index.html` inneholder `<h1>...Krav og veileder for turistfiskebedrift</h1>`