### PR TITLE
Extract sitewide footer into Layout (+ Facebook links)

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,81 @@
+---
+import { Image } from 'astro:assets';
+import logo from '../assets/logo.png';
+---
+
+<footer id="kontakt" class="bg-gray-900 text-gray-300 py-12 sm:py-16">
+  <div class="max-w-6xl mx-auto px-4">
+    <div class="grid md:grid-cols-4 gap-8 mb-8">
+      <!-- Company Info -->
+      <div>
+        <div class="flex items-center gap-2 mb-4">
+          <Image src={logo} alt="export.fish logo" class="h-10 w-10" width={40} height={40} />
+          <span class="text-xl font-bold text-white">Eksportfiske</span>
+        </div>
+        <p class="text-sm text-gray-400">
+          Enkel fangstrapportering for turistfiskebedrifter i hele Norge. Godkjent av Fiskeridirektoratet.
+        </p>
+      </div>
+
+      <!-- Product -->
+      <div>
+        <h3 class="text-white font-semibold mb-4">Produkt</h3>
+        <ul class="space-y-2 text-sm">
+          <li><a href="/#fordeler" class="hover:text-primary transition">Fordeler</a></li>
+          <li><a href="/#hvordan-virker-det" class="hover:text-primary transition">Hvordan virker det?</a></li>
+          <li><a href="/#lovkrav" class="hover:text-primary transition">Lovkrav</a></li>
+          <li><a href="https://test.export.fish" target="_blank" rel="noopener noreferrer" class="hover:text-primary transition">Test appen</a></li>
+        </ul>
+      </div>
+
+      <!-- Resources -->
+      <div>
+        <h3 class="text-white font-semibold mb-4">Ressurser</h3>
+        <ul class="space-y-2 text-sm">
+          <li><a href="https://www.fiskeridir.no/turistfiske/rapportering-for-turistfiskebedrifter" target="_blank" rel="noopener noreferrer" class="hover:text-primary transition">Fiskeridirektoratet</a></li>
+          <li><a href="https://lovdata.no/dokument/SF/forskrift/2017-07-05-1141" target="_blank" rel="noopener noreferrer" class="hover:text-primary transition">Forskrift om rapportering</a></li>
+          <li><a href="https://www.nhoreiseliv.no/bransjer/opplevelser/fisketurisme/" target="_blank" rel="noopener noreferrer" class="hover:text-primary transition">NHO Reiseliv - Fisketurisme</a></li>
+        </ul>
+      </div>
+
+      <!-- Contact -->
+      <div>
+        <h3 class="text-white font-semibold mb-4">Kontakt</h3>
+        <ul class="space-y-2 text-sm">
+          <li>
+            <a href="mailto:kontakt@eksportfiske.no" class="hover:text-primary transition">
+              <!--email_off-->kontakt@eksportfiske.no<!--/email_off-->
+            </a>
+          </li>
+          <li>
+            <a href="/om-oss" class="hover:text-primary transition text-gray-400">
+              Om oss
+            </a>
+          </li>
+          <li>
+            <a href="/kontakt" class="hover:text-primary transition text-gray-400">
+              Kontaktinformasjon
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- Bottom Bar -->
+    <div class="border-t border-gray-800 pt-8 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-gray-400">
+      <p>&copy; {new Date().getFullYear()} Eksportfiske.no. Alle rettigheter reservert.</p>
+      <a
+        href="https://www.facebook.com/profile.php?id=61576429696153"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Følg Eksportfiske på Facebook"
+        class="inline-flex items-center gap-2 hover:text-primary transition"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-4 h-4" aria-hidden="true">
+          <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
+        </svg>
+        Følg oss på Facebook
+      </a>
+    </div>
+  </div>
+</footer>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,6 +3,7 @@ import '../styles/global.css';
 import { getImage, Image } from 'astro:assets';
 import defaultOgImage from '../assets/hero-bg.jpg';
 import CookieConsent from '../components/CookieConsent.astro';
+import Footer from '../components/Footer.astro';
 import logo from '../assets/logo.png';
 
 import type { ImageMetadata } from 'astro';
@@ -368,6 +369,7 @@ const markdownURL = new URL(_mdPathname + '.md', siteUrl).href;
     <main>
       <slot />
     </main>
+    <Footer />
     <CookieConsent />
     <script>
       document.addEventListener('DOMContentLoaded', () => {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,9 +15,6 @@ import kveite from '../assets/kveite.png';
 import uer from '../assets/uer.png';
 import steinbit from '../assets/steinbit.png';
 import sei from '../assets/sei.png';
-
-// Import logo
-import logo from '../assets/logo.png';
 ---
 
 <Layout
@@ -1001,71 +998,6 @@ import logo from '../assets/logo.png';
           </div>
   </section>
 
-  <!-- Footer -->
-  <footer id="kontakt" class="bg-gray-900 text-gray-300 py-12 sm:py-16">
-    <div class="max-w-6xl mx-auto px-4">
-      <div class="grid md:grid-cols-4 gap-8 mb-8">
-        <!-- Company Info -->
-        <div>
-          <div class="flex items-center gap-2 mb-4">
-            <Image src={logo} alt="export.fish logo" class="h-10 w-10" width={40} height={40} />
-            <span class="text-xl font-bold text-white">Eksportfiske</span>
-          </div>
-          <p class="text-sm text-gray-400">
-            Enkel fangstrapportering for turistfiskebedrifter i hele Norge. Godkjent av Fiskeridirektoratet.
-          </p>
-        </div>
-
-        <!-- Product -->
-        <div>
-          <h3 class="text-white font-semibold mb-4">Produkt</h3>
-          <ul class="space-y-2 text-sm">
-            <li><a href="#fordeler" class="hover:text-primary transition">Fordeler</a></li>
-            <li><a href="#hvordan-virker-det" class="hover:text-primary transition">Hvordan virker det?</a></li>
-            <li><a href="#lovkrav" class="hover:text-primary transition">Lovkrav</a></li>
-            <li><a href="https://test.export.fish" target="_blank" rel="noopener noreferrer" class="hover:text-primary transition">Test appen</a></li>
-          </ul>
-        </div>
-
-        <!-- Resources -->
-        <div>
-          <h3 class="text-white font-semibold mb-4">Ressurser</h3>
-          <ul class="space-y-2 text-sm">
-            <li><a href="https://www.fiskeridir.no/turistfiske/rapportering-for-turistfiskebedrifter" target="_blank" rel="noopener noreferrer" class="hover:text-primary transition">Fiskeridirektoratet</a></li>
-            <li><a href="https://lovdata.no/dokument/SF/forskrift/2017-07-05-1141" target="_blank" rel="noopener noreferrer" class="hover:text-primary transition">Forskrift om rapportering</a></li>
-            <li><a href="https://www.nhoreiseliv.no/bransjer/opplevelser/fisketurisme/" target="_blank" rel="noopener noreferrer" class="hover:text-primary transition">NHO Reiseliv - Fisketurisme</a></li>
-          </ul>
-        </div>
-
-        <!-- Contact -->
-        <div>
-          <h3 class="text-white font-semibold mb-4">Kontakt</h3>
-          <ul class="space-y-2 text-sm">
-            <li>
-              <a href="mailto:kontakt@eksportfiske.no" class="hover:text-primary transition">
-                <!--email_off-->kontakt@eksportfiske.no<!--/email_off-->
-              </a>
-            </li>
-            <li>
-              <a href="/om-oss" class="hover:text-primary transition text-gray-400">
-                Om oss
-              </a>
-            </li>
-            <li>
-              <a href="/kontakt" class="hover:text-primary transition text-gray-400">
-                Kontaktinformasjon
-              </a>
-            </li>
-          </ul>
-        </div>
-      </div>
-
-      <!-- Bottom Bar -->
-      <div class="border-t border-gray-800 pt-8 text-center text-sm text-gray-400">
-        <p>&copy; {new Date().getFullYear()} Eksportfiske.no. Alle rettigheter reservert.</p>
-      </div>
-    </div>
-  </footer>
 </Layout>
 
 <script>

--- a/src/pages/registrer/takk.astro
+++ b/src/pages/registrer/takk.astro
@@ -99,6 +99,30 @@ import Layout from '../../layouts/Layout.astro';
         </div>
       </div>
 
+      <!-- Facebook follow card -->
+      <div class="mt-8 bg-white rounded-2xl shadow-lg border border-gray-200 p-8 md:p-12 text-center">
+        <div class="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6 text-blue-600" aria-hidden="true">
+            <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
+          </svg>
+        </div>
+        <h2 class="text-xl font-semibold text-gray-900 mb-3">Følg oss på Facebook</h2>
+        <p class="text-gray-600 mb-6">
+          Hold deg oppdatert på regelendringer, tips og nye funksjoner i export.fish.
+        </p>
+        <a
+          href="https://www.facebook.com/profile.php?id=61576429696153"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 px-6 rounded-lg transition-colors"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-4 h-4" aria-hidden="true">
+            <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
+          </svg>
+          Følg oss på Facebook
+        </a>
+      </div>
+
       <!-- Contact info -->
       <div class="mt-12 text-center">
         <p class="text-gray-600 mb-6">


### PR DESCRIPTION
## What this does

**Primary change: the footer is now sitewide.** Until now the footer was inlined only in `index.astro`, so `/kontakt/`, `/om-oss/`, `/vilkar/`, `/registrer/`, `/registrer/takk/`, `/registrering/`, `/blogg/`, all blog posts, `/404`, and `/qr/` had no footer at all — navigational dead-ends with only the top nav.

### Footer extraction
- New `src/components/Footer.astro` — extracted from `index.astro` (it was the only sitewide footer; the blog slug page had no competing one, so extraction was clean).
- `src/layouts/Layout.astro` — imports and renders `<Footer />` after `<main>`, before `<CookieConsent />`. **Every page now has a footer.**
- `src/pages/index.astro` — inline footer block removed; unused `logo` import removed.
- Footer anchor links updated from `#fordeler` → `/#fordeler` etc. so they navigate correctly from any page (previously they'd only work on the homepage).

### Riding along: Facebook follow links
- Footer bottom bar: "Følg oss på Facebook" icon link → `https://www.facebook.com/profile.php?id=61576429696153` (`target="_blank"`, `rel="noopener noreferrer"`, not `nofollow` — it's our own property).
- `src/pages/registrer/takk.astro` — a "Følg oss på Facebook" card added after the "Hva skjer nå?" cards, before "Kontakt oss". Matches the page's existing `rounded-2xl shadow-lg border border-gray-200` card styling. The customer just registered, so the framing is staying updated on regelendringer og nye funksjoner. No em dashes.

## Verification
- `npm run build` clean.
- FB URL present in `dist/index.html` (footer) and `dist/registrer/takk/index.html` (card).
- Footer now present in `dist/kontakt/index.html` and other previously-footerless pages.

## Follow-ups
None blocking. The takk page is `noindex` so the card is pure UX, no SEO impact.