### PR TITLE
Gjør footeren klistret til bunnen på korte sider

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -329,7 +329,7 @@ const markdownURL = new URL(_mdPathname + '.md', siteUrl).href;
     <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "6674d462a18d4e0bb16ef63c13ace4a9"}'></script>
     <!-- End Cloudflare Web Analytics -->
   </head>
-  <body class="bg-gray-50 text-gray-900">
+  <body class="bg-gray-50 text-gray-900 min-h-screen flex flex-col">
     <!-- Fixed Navigation -->
     <header class="fixed top-0 w-full bg-white/90 backdrop-blur-sm border-b border-gray-200 z-50">
       <nav class="container mx-auto px-4 py-4 flex justify-between items-center" aria-label="Hovedmeny">
@@ -366,7 +366,7 @@ const markdownURL = new URL(_mdPathname + '.md', siteUrl).href;
         </a>
       </nav>
     </header>
-    <main>
+    <main class="flex-1">
       <slot />
     </main>
     <Footer />


### PR DESCRIPTION
## Bakgrunn

`<body>` hadde ingen flex-layout, så på korte sider (`/404`, `/qr/`, en tynn `/kontakt/`) flyter footeren opp midt på skjermen med tom plass under.

## Endring i `src/layouts/Layout.astro`

- `<body>` → `min-h-screen flex flex-col` (fyller viewporten, kolonnelayout)
- `<main>` → `flex-1` (vokser og spiser opp ledig plass, dytter footeren til bunnen)

Standard "sticky footer"-mønster. Den fixed headeren er ute av flyten, så layouten påvirkes ikke.

## Verifisert

- `npm run build` rent, 25 sider
- `<body class="...min-h-screen flex flex-col">` og `<main class="flex-1">` bekreftet i `dist/index.html`, `dist/kontakt/index.html`, `dist/404.html`