### PR TITLE
Legg til rammer og styling på blogg-tabeller

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -24,3 +24,32 @@ section[id] {
   margin-right: auto;
   max-width: 100%;
 }
+
+/* Blog post tables (markdown-rendered, no typography plugin).
+   display:block + overflow-x:auto makes wide tables scroll horizontally
+   on narrow viewports instead of overflowing the layout; cells still wrap. */
+article table {
+  display: block;
+  overflow-x: auto;
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.95rem;
+}
+
+article th,
+article td {
+  border: 1px solid #d1d5db;
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+article th {
+  background-color: #f3f4f6;
+  font-weight: 600;
+}
+
+article tbody tr:nth-child(even) td {
+  background-color: #f9fafb;
+}


### PR DESCRIPTION
## Bakgrunn

Blogg-innhold rendres uten typografi-plugin og uten tabell-CSS, så markdown-tabeller (f.eks. minstemål/fredningstid-tabellene i `minstemal-fredningstider-tabell`, og tabeller i `sesongkalender`/`kveitefiske` i køen) vises uten rammer eller styling.

## Endring i `src/styles/global.css`

Lagt til styling for `article table` (alle blogg-innleggstabeller):

- `border: 1px solid #d1d5db` på celler, `border-collapse: collapse`
- Header-rad: lys grå bakgrunn (`#f3f4f6`), fet skrift
- Stripet annenhver rad (`#f9fafb`)
- `display: block; overflow-x: auto` — brede tabeller scroller horisontalt på smale skjermer i stedet for å sprenge layouten; celler bryter fortsatt tekst normalt
- Litt mindre fontstørrelse (0.95rem) og romslig cellepadding

Gjelder alle blogg-innlegg konsistent, både eksisterende og fremtidige.

## Verifisert

- `npm run build` rent, 26 sider
- `article table`-regelen kompilert inn i `dist/_astro/*.css`
- Tabellene i `dist/blogg/minstemal-fredningstider-tabell/index.html` rendres som `<table>/<th>/<td>`