### PR TITLE
Bruk updatedDate: Article dateModified, Oppdatert-dato, backfill Tolletaten

### DIFF
--- a/src/content/blog/tolletaten-grense-fisk-bot-unnga.md
+++ b/src/content/blog/tolletaten-grense-fisk-bot-unnga.md
@@ -4,6 +4,7 @@ description: "Tolletaten beslagla 23 tonn fisk i 2025, nesten dobbelt så mye so
 slug: "tolletaten-grense-fisk-bot-unnga"
 guid: "aab498bb-1062-4fa1-a2c9-6acc6bd1bf58"
 pubDate: 2026-05-09T08:00:00.000Z
+updatedDate: 2026-05-10T00:00:00.000Z
 author: "Kim Eik"
 tags: []
 image:

--- a/src/pages/blogg/[...slug].astro
+++ b/src/pages/blogg/[...slug].astro
@@ -35,6 +35,7 @@ const jsonLd = {
   headline: entry.data.title,
   description: entry.data.description,
   datePublished: entry.data.pubDate.toISOString(),
+  dateModified: (entry.data.updatedDate ?? entry.data.pubDate).toISOString(),
   url: canonicalURL,
   author: {
     '@type': 'Person',
@@ -90,6 +91,9 @@ const breadcrumbLd = {
           class="text-sm text-gray-500 mb-3 block"
         >
           {formatDate(entry.data.pubDate)}
+          {entry.data.updatedDate && (
+            <span class="text-gray-400">· Oppdatert {formatDate(entry.data.updatedDate)}</span>
+          )}
         </time>
         <h1 class="text-3xl md:text-4xl font-bold text-gray-900 leading-tight mb-4">
           {entry.data.title}


### PR DESCRIPTION
## Bakgrunn

Skjemaet (`content.config.ts`) hadde allerede `updatedDate`-feltet, og `astro.config.mjs` brukte det allerede til sitemap-`<lastmod>` (`updatedDate || pubDate`). Men feltet var ellers ubrukt: Article-JSON-LD manglet `dateModified`, og artikkelsiden viste ikke "Oppdatert"-dato. I tillegg ble Tolletaten-artikkelen vesentlig endret 10. mai (2025-tall, 404-fiks) uten at `updatedDate` ble satt, så sitemap'en sa fortsatt `lastmod: 2026-05-09`.

## Endringer

### `src/pages/blogg/[...slug].astro`
- Article-JSON-LD: lagt til `dateModified: (updatedDate ?? pubDate).toISOString()`
- Artikkelheader: viser "· Oppdatert {dato}" etter publiseringsdatoen *kun når* `updatedDate` er satt

### `src/content/blog/tolletaten-grense-fisk-bot-unnga.md`
- Lagt til `updatedDate: 2026-05-10T00:00:00.000Z` (substansiell innholdsendring 10. mai: oppdatert til 2025-tall, fikset 404-lenke)

## Verifisert (`npm run build`, 26 sider)
- `dist/blogg/tolletaten-grense-fisk-bot-unnga/index.html`: `"dateModified":"2026-05-10T00:00:00.000Z"` og "Oppdatert 10. mai 2026" i headeren
- En ikke-oppdatert artikkel (`nullfangst-...`) viser ingen "Oppdatert"-tekst
- `dist/sitemap-0.xml`: `lastmod` for Tolletaten er nå `2026-05-10` (var `2026-05-09`)

## Konvensjon fremover
Sett `updatedDate` (dato, `YYYY-MM-DDT00:00:00.000Z`) når en publisert artikkels innhold endres vesentlig. Det oppdaterer automatisk sitemap-`<lastmod>`, JSON-LD `dateModified`, og "Oppdatert"-visningen.

## Mulig oppfølging
Andre allerede-merget artikler fikk også innholdsendringer etter publisering (`leie-hytte-med-bat-sjekkliste` — sdir-bytte 10.–11. mai; `fritidsfiske-sportsfiske-turistfiske-forskjell` og `slik-registrerer-du-turistfiskebedrift` — lenkefjerning 10. mai). Disse kan også få `updatedDate` om ønskelig.