### PR TITLE
Oppdater onboarding-copy for automatisk aktivering (issue #274)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -227,7 +227,7 @@ const markdownURL = new URL(_mdPathname + '.md', siteUrl).href;
             "name": "Hvor lang tid tar det å sette opp?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Så snart du er registrert i vårt faktureringssystem er appen klar til bruk. Du får en unik lenke til ditt eget subdomene (f.eks. ditt-firma.export.fish) som du deler med turistene. De kan starte med fangstrapportering umiddelbart - ingen opplæring eller konfigurasjon nødvendig."
+              "text": "Appen er klar til bruk med en gang du har registrert bedriften. Du får en e-post med lenke til dashbordet og QR-koden du deler med turistene. Faktureringen ordnes i bakgrunnen og er ikke en betingelse for tilgang. Turistene kan starte med fangstrapportering umiddelbart, ingen opplæring eller konfigurasjon nødvendig."
             }
           },
           {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -781,8 +781,8 @@ import sei from '../assets/sei.png';
           </summary>
           <div class="px-6 py-4 text-gray-600 border-t border-gray-100">
             <p>
-              Så snart du er registrert i vårt faktureringssystem (noe som kan ta noen dager da dette er en manuell prosess) er appen klar til bruk. Du får en unik lenke til ditt eget subdomene (f.eks. ditt-firma.export.fish) som du deler med turistene.
-              De kan starte med fangstrapportering umiddelbart - ingen opplæring eller konfigurasjon nødvendig.
+              Appen er klar til bruk med en gang du har registrert bedriften. Du får en e-post med lenke til dashbordet og QR-koden du deler med turistene. Faktureringen ordnes i bakgrunnen og er ikke en betingelse for tilgang.
+              Turistene kan starte med fangstrapportering umiddelbart, ingen opplæring eller konfigurasjon nødvendig.
             </p>
           </div>
         </details>

--- a/src/pages/registrer/ny-kunde.astro
+++ b/src/pages/registrer/ny-kunde.astro
@@ -321,7 +321,7 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
           </button>
 
           <p class="text-sm text-gray-500 text-center">
-            Etter at du er lagt til i systemet får du tilgang til ditt eget export.fish-subdomene for rapportering.
+            Etter registrering får du tilgang til ditt eget export.fish-subdomene for rapportering med en gang.
           </p>
         </form>
       </div>

--- a/src/pages/registrer/takk.astro
+++ b/src/pages/registrer/takk.astro
@@ -43,7 +43,7 @@ import Layout from '../../layouts/Layout.astro';
             </div>
             <div>
               <p class="font-medium text-gray-900">Bedriften din er registrert</p>
-              <p class="text-sm text-gray-600">Du vil straks motta en e-post med lenke til dashbordet og QR-koden for turistene. Ingen ekstra steg.</p>
+              <p class="text-sm text-gray-600">Du vil straks motta en e-post med lenke til dashbordet og QR-koden for turistene, og kan komme i gang med en gang.</p>
             </div>
           </li>
         </ul>

--- a/src/pages/registrer/takk.astro
+++ b/src/pages/registrer/takk.astro
@@ -4,7 +4,7 @@ import Layout from '../../layouts/Layout.astro';
 
 <Layout
   title="Takk - export.fish"
-  description="Vi har mottatt din henvendelse. Sjekk e-posten din for å fullføre registreringen."
+  description="Vi har mottatt din henvendelse. Du vil snart motta en e-post med neste steg."
   noindex
 >
   <!-- Hero Section -->
@@ -42,8 +42,8 @@ import Layout from '../../layouts/Layout.astro';
               </svg>
             </div>
             <div>
-              <p class="font-medium text-gray-900">Din henvendelse er mottatt</p>
-              <p class="text-sm text-gray-600">Du vil snart motta en e-post med lenke for å fullføre registreringen basert på opplysningene du har oppgitt.</p>
+              <p class="font-medium text-gray-900">Bedriften din er registrert</p>
+              <p class="text-sm text-gray-600">Du vil straks motta en e-post med lenke til dashbordet og QR-koden for turistene. Ingen ekstra steg.</p>
             </div>
           </li>
         </ul>
@@ -67,8 +67,8 @@ import Layout from '../../layouts/Layout.astro';
               </svg>
             </div>
             <div>
-              <p class="font-medium text-gray-900">Registreringen er mottatt</p>
-              <p class="text-sm text-gray-600">Vi har mottatt all informasjon og oppretter din konto.</p>
+              <p class="font-medium text-gray-900">Kontoen din er klar</p>
+              <p class="text-sm text-gray-600">Vi har opprettet kontoen din, og dashbord-lenken og QR-koden er sendt til e-posten din.</p>
             </div>
           </li>
           <li class="flex items-start gap-4">
@@ -76,17 +76,8 @@ import Layout from '../../layouts/Layout.astro';
               <span class="text-primary font-semibold text-sm">1</span>
             </div>
             <div>
-              <p class="font-medium text-gray-900">Kontoen din aktiveres</p>
-              <p class="text-sm text-gray-600">Vi verifiserer informasjonen og setter opp ditt export.fish-subdomene. Du mottar en e-post når alt er klart.</p>
-            </div>
-          </li>
-          <li class="flex items-start gap-4">
-            <div class="w-8 h-8 bg-primary/10 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5">
-              <span class="text-primary font-semibold text-sm">2</span>
-            </div>
-            <div>
-              <p class="font-medium text-gray-900">Del lenken med turistene</p>
-              <p class="text-sm text-gray-600">Når kontoen er aktiv, kan du dele din unike export.fish-lenke med turistene slik at de kan registrere fangst selv.</p>
+              <p class="font-medium text-gray-900">Del din unike lenke med turistene</p>
+              <p class="text-sm text-gray-600">Del ditt export.fish-subdomene og QR-koden med turistene, slik at de kan registrere fangst selv.</p>
             </div>
           </li>
         </ul>
@@ -153,8 +144,8 @@ import Layout from '../../layouts/Layout.astro';
     const interestContent = document.getElementById('interest-content');
     const registrertContent = document.getElementById('registrert-content');
 
-    if (title) title.textContent = 'Registreringen er fullført!';
-    if (subtitle) subtitle.textContent = 'Takk for at du valgte export.fish. Vi setter opp kontoen din nå.';
+    if (title) title.textContent = 'Bedriften din er registrert!';
+    if (subtitle) subtitle.textContent = 'Takk for at du valgte export.fish. Kontoen din er klar til bruk.';
     if (interestContent) interestContent.classList.add('hidden');
     if (registrertContent) registrertContent.classList.remove('hidden');
   }


### PR DESCRIPTION
## Bakgrunn

Lukker #274.

Backend-endring i eik-it/export.fish#603 gjør at nye bedrifter nå opprettes med `is_active = true` med en gang, og velkomst-e-posten (dashbord-lenke + QR-kode) sendes ved registrering, ikke etter en manuell aktiveringslenke. Fiken/fakturering er fortsatt en intern ops-oppgave, men blokkerer ikke tilgang.

**VIKTIG: Denne PRen skal ikke merges før eik-it/export.fish#603 er rullet ut i produksjon, slik at copy og faktisk oppførsel skifter samtidig.**

## Filer endret

### `src/pages/registrer/takk.astro`
- `<Layout description>`: Fjernet "fullføre registreringen"-framing
- Interest-state listepunkt: Rewritten fra "e-post med lenke for å fullføre registreringen" til "e-post med dashbord-lenke og QR-kode, ingen ekstra steg"
- Registrert-state: Kollapset 3-stegs-liste til 2 steg. Fjernet "Kontoen din aktiveres" / "Vi verifiserer informasjonen og setter opp ditt export.fish-subdomene. Du mottar en e-post når alt er klart." Nytt steg 1: "Kontoen din er klar" / dashbord-lenke og QR-kode er sendt. Nytt steg 2: "Del din unike lenke med turistene".
- Inline JS: Tittel endret fra "Registreringen er fullført!" til "Bedriften din er registrert!". Undertekst endret fra "Vi setter opp kontoen din nå." til "Kontoen din er klar til bruk."

### `src/pages/registrer/ny-kunde.astro`
- Linje 324: Fjernet "lagt til i systemet" (som impliserte en manuell ops-prosess). Ny tekst: "Etter registrering får du tilgang til ditt eget export.fish-subdomene for rapportering med en gang."

### `src/pages/index.astro`
- FAQ "Hvor lang tid tar det å sette opp?": Fjernet referanse til "faktureringssystem" og "manuell prosess". Ny tekst forklarer at appen er klar umiddelbart etter registrering, e-post med dashbord-lenke og QR-kode sendes med en gang, og fakturering ordnes i bakgrunnen.

### `src/layouts/Layout.astro`
- FAQPage JSON-LD: Oppdatert "Hvor lang tid tar det å sette opp?"-svaret til å matche den synlige FAQ-teksten i `index.astro` eksakt.

## Hva er ikke endret

- `registrering.astro` (steg 4 og 5): Verifisert rent, ingen referanser til manuell godkjenning fra vår side.
- FAQ "Hvordan fungerer prøveperioden?": Ingen aktiveringslenke forutsatt som startsignal for prøveperioden, ingen endringer nødvendig.
- Facebook-kort, kontaktlenke og spam-tips på takk-siden er uendret.

## Bygg

`npm run build` kjørte rent. Verifisert at `dist/registrer/takk/index.html` ikke lenger inneholder "Kontoen din aktiveres" / "Vi verifiserer informasjonen og setter opp" / "Vi setter opp kontoen din nå" / "lagt til i systemet", og at `dist/index.html` FAQ og JSON-LD matcher.