### PR TITLE
FAQ: hvorfor kun årlig fakturering ved sporadiske gjester

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -756,6 +756,47 @@ import sei from '../assets/sei.png';
           </div>
         </details>
 
+        <!-- FAQ 6.6 - Sporadic guests / shorter billing -->
+        <details class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden group">
+          <summary class="cursor-pointer px-6 py-5 font-semibold text-lg text-gray-900 hover:bg-gray-50 transition-colors list-none flex justify-between items-center">
+            <span>Kan jeg få et kortere abonnement hvis jeg bare har sporadiske fiskegjester?</span>
+            <svg class="w-5 h-5 text-gray-500 transition-transform group-open:rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+            </svg>
+          </summary>
+          <div class="px-6 py-4 text-gray-600 border-t border-gray-100">
+            <p class="mb-3">
+              Vi tilbyr kun årlig fakturering. Prisen er lagt lavt (<strong>990 kr/år eks. mva.</strong>) for at terskelen for å rapportere korrekt skal være så lav som mulig, og en enkel abonnementsmodell er det som gjør at vi kan holde den der.
+            </p>
+            <p class="mb-3">
+              Det er likevel verdt å være klar over at den daglige rapporteringsplikten til Fiskeridirektoratet gjelder bredere enn mange tror:
+            </p>
+            <ul class="space-y-2 mb-3">
+              <li class="flex items-start gap-2">
+                <svg class="w-5 h-5 text-green-600 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" fill-rule="evenodd"></path>
+                </svg>
+                <span>Plikten utløses av at dere tar betalt fra gjester som fisker med båt dere stiller til disposisjon</span>
+              </li>
+              <li class="flex items-start gap-2">
+                <svg class="w-5 h-5 text-green-600 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" fill-rule="evenodd"></path>
+                </svg>
+                <span>Den gjelder uavhengig av om dere markedsfører dere som turistfiskebedrift</span>
+              </li>
+              <li class="flex items-start gap-2">
+                <svg class="w-5 h-5 text-green-600 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" fill-rule="evenodd"></path>
+                </svg>
+                <span>Den gjelder uavhengig av om gjestene tar med fisk hjem til utlandet</span>
+              </li>
+            </ul>
+            <p class="text-sm">
+              Med andre ord dekker abonnementet hele rapporteringsbehovet gjennom året, ikke bare ett enkelt opphold. Er dere usikre på om dette passer, anbefaler vi å starte med prøveperioden (1 måned gratis) og se hvordan det fungerer i praksis. Skulle årlig fakturering likevel ikke passe etterpå, er det bare å gi beskjed på e-post.
+            </p>
+          </div>
+        </details>
+
         <!-- FAQ 7 -->
         <details class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden group">
           <summary class="cursor-pointer px-6 py-5 font-semibold text-lg text-gray-900 hover:bg-gray-50 transition-colors list-none flex justify-between items-center">


### PR DESCRIPTION
## Bakgrunn

Kundehenvendelse fra utleier som bare har én fiskegjest i sesongen og ønsket kortere abonnementsperiode eller delvis kreditering. Daniel svarte grundig på e-post — denne FAQ-en kondenserer hovedpoengene slik at fremtidige kunder med samme situasjon får svar direkte på nettsiden.

## Endringer

- Ny FAQ-oppføring etter "Hvordan fungerer prøveperioden?" (relatert tema: fakturering/pris)
- Spørsmål: "Kan jeg få et kortere abonnement hvis jeg bare har sporadiske fiskegjester?"
- Svar dekker tre hovedpunkter:
  - Hvorfor årlig fakturering er eneste modell (lav pris forutsetter enkel modell)
  - At rapporteringsplikten gjelder bredere enn mange tror (ikke avhengig av eksport eller markedsføring som turistfiskebedrift)
  - At prøveperioden er en lav-risiko måte å teste på

## Test

- [x] `npm run build` OK
- [ ] Visuell sjekk i deployet versjon