### PR TITLE
Korriger forskriftshenvisning i vilkar

### DIFF
--- a/src/content/legal/vilkar.md
+++ b/src/content/legal/vilkar.md
@@ -4,7 +4,7 @@ Velkommen til export.fish. Disse vilkårene regulerer bruken av våre tjenester 
 
 ## 1. Tjenestebeskrivelse
 
-export.fish leverer en digital plattform for fangstrapportering fra turistfiskevirksomhet i samsvar med Forskrift om rapportering av fangst fra turistfiskevirksomhet (2017-07-05-1141).
+Tjenesten er utformet for å støtte etterlevelse av forskrift 5. juli 2017 nr. 1141 om turistfiskevirksomheter og forskrift 20. desember 2017 nr. 2445 om rapportering av fangster fra turistfiskevirksomheter.
 
 Tjenesten omfatter:
 - Webbasert registreringsverktøy for turister (Progressive Web App).
@@ -196,7 +196,8 @@ Tvister søkes løst i minnelighet. Dersom minnelig løsning ikke oppnås, skal 
 
 ### 11.3 Gjeldende forskrifter
 Tjenesten er utformet for å oppfylle:
-- Forskrift om rapportering av fangst fra turistfiskevirksomhet (2017-07-05-1141).
+- Forskrift 5. juli 2017 nr. 1141 om turistfiskevirksomheter.
+- Forskrift 20. desember 2017 nr. 2445 om rapportering av fangster fra turistfiskevirksomheter.
 - Personopplysningsloven og GDPR.
 - Arkivloven.
 - Øvrig relevant lovgivning.

--- a/src/content/legal/vilkar.md
+++ b/src/content/legal/vilkar.md
@@ -4,7 +4,7 @@ Velkommen til export.fish. Disse vilkårene regulerer bruken av våre tjenester 
 
 ## 1. Tjenestebeskrivelse
 
-Tjenesten er utformet for å støtte etterlevelse av forskrift 5. juli 2017 nr. 1141 om turistfiskevirksomheter og forskrift 20. desember 2017 nr. 2445 om rapportering av fangster fra turistfiskevirksomheter.
+Tjenesten er utformet for å støtte etterlevelse av [FOR-2017-07-05-1141 om turistfiskevirksomheter](https://lovdata.no/dokument/SF/forskrift/2017-07-05-1141) og [FOR-2017-12-20-2445 om rapportering av fangster fra turistfiskevirksomheter](https://lovdata.no/dokument/SF/forskrift/2017-12-20-2445).
 
 Tjenesten omfatter:
 - Webbasert registreringsverktøy for turister (Progressive Web App).
@@ -196,8 +196,8 @@ Tvister søkes løst i minnelighet. Dersom minnelig løsning ikke oppnås, skal 
 
 ### 11.3 Gjeldende forskrifter
 Tjenesten er utformet for å oppfylle:
-- Forskrift 5. juli 2017 nr. 1141 om turistfiskevirksomheter.
-- Forskrift 20. desember 2017 nr. 2445 om rapportering av fangster fra turistfiskevirksomheter.
+- [FOR-2017-07-05-1141 om turistfiskevirksomheter](https://lovdata.no/dokument/SF/forskrift/2017-07-05-1141).
+- [FOR-2017-12-20-2445 om rapportering av fangster fra turistfiskevirksomheter](https://lovdata.no/dokument/SF/forskrift/2017-12-20-2445).
 - Personopplysningsloven og GDPR.
 - Arkivloven.
 - Øvrig relevant lovgivning.


### PR DESCRIPTION
## Bakgrunn (audit-finding)

Vilkår blandet to forskrifter. Paragraf 1 og 11.3 siterte 2017-07-05-1141 som \"Forskrift om rapportering av fangst fra turistfiskevirksomhet\", men dette er feil tittel for den forskriften. Korrekte referanser:

- **FOR-2017-07-05-1141** = Forskrift om turistfiskevirksomheter (registrering, rapporteringsplikt, kontroll)
- **FOR-2017-12-20-2445** = Forskrift om rapportering av fangster fra turistfiskevirksomheter (det dedikerte rapporteringssystemet)

## Endringer

- `src/content/legal/vilkar.md` punkt 1: ny formulering nevner begge forskrifter korrekt
- `src/content/legal/vilkar.md` punkt 11.3: liste over gjeldende forskrifter utvidet med begge forskrifter med korrekte titler og datoer

## Test plan

- [ ] Sjekk `/vilkar` at begge forskriftshenvisninger vises korrekt
- [ ] Verifiser at lenker til lovdata.no/dokument/SF/forskrift/2017-07-05-1141 og /2017-12-20-2445 begge fungerer
- [ ] `npm run build` passerer (verifisert lokalt)