### PR TITLE
Presiser kvoteregel: per person, inntil to ganger per kalenderår

### DIFF
--- a/src/content/blog/daglig-fangstrapportering-turistfiske.md
+++ b/src/content/blog/daglig-fangstrapportering-turistfiske.md
@@ -53,7 +53,7 @@ Det tredje er timing. Mange tenker at så lenge alt er ført før gjestene drar,
 
 Dette er kanskje det punktet som merkes best i praksis. Utførselsdokumentasjon kan ikke utstedes før rapport er sendt inn. Derfor henger rapportering og gjesteopplevelse tett sammen.
 
-Husk også at gjestene dine kan ta med seg inntil 15 kg fisk per opphold ut av landet — en kvote som gjelder fra 1.1.2026 og reduseres til 10 kg fra 1.1.2027. Uten fullstendig og godkjent fangstrapportering kan du ikke utstede den dokumentasjonen de trenger ved grensen.
+Husk også at gjestene dine kan ta med seg inntil 15 kg fisk per person ut av landet, inntil to ganger per kalenderår (2026-kvoten, reduseres til 10 kg fra 1.1.2027). Uten fullstendig og godkjent fangstrapportering kan du ikke utstede den dokumentasjonen de trenger ved grensen.
 
 Hvis du sitter med manuelle notater siste kveld før avreise, kan hele prosessen stoppe opp fordi én fangstdag mangler eller er uklar. Da blir du sittende og ringe gjester som allerede pakker bil eller står på kaia. Det er dårlig bruk av tid for deg, og det gir en unødvendig dårlig avslutning på oppholdet. Mangler i rapporteringen er heller ikke bare et praktisk problem — det er også den vanligste årsaken til at utleiere lurer på [konsekvensene av manglende fangstrapportering](/blogg/bot-for-turistfiske-rapportering/).
 

--- a/src/content/blog/trofefisk-fjernet-turistfiske.md
+++ b/src/content/blog/trofefisk-fjernet-turistfiske.md
@@ -25,7 +25,7 @@ Fra 1. august 2025 er denne retten borte. Det er ikke lenger et eget tillegg for
 
 ## Hva er utførselskvoten nå?
 
-Utførselskvoten som gjelder fra 1. januar 2026 er 15 kg fisk eller fiskeprodukter per person per tur, og du kan benytte kvoten to ganger per kalenderår. Fra 1. januar 2027 reduseres den ytterligere til 10 kg to ganger i året.
+Utførselskvoten som gjelder fra 1. januar 2026 er 15 kg fisk eller fiskeprodukter per person, inntil to ganger per kalenderår. Fra 1. januar 2027 reduseres den ytterligere til 10 kg to ganger i året.
 
 Det er bare mulig å utføre fisk dersom fisket har foregått hos en [registrert turistfiskebedrift](/blogg/ma-du-registrere-turistfiskebedrift/). Gjestene må kunne dokumentere dette ved grensepasseringen. Tolletaten kontrollerer, og bøtene er høye: 8 000 kroner pluss 200 kroner per kilo ulovlig utført fisk.
 

--- a/src/content/blog/utforselskvote-fisk-2026.md
+++ b/src/content/blog/utforselskvote-fisk-2026.md
@@ -1,6 +1,6 @@
 ---
 title: "Utførselskvote for fisk i 2026"
-description: "Fra 1.1.2026 er utførselskvoten 15 kg per opphold, og kuttes til 10 kg fra 2027. Slik fungerer reglene for turistfiskebedrifter — og hva det betyr for gjestene dine."
+description: "Fra 1.1.2026 er utførselskvoten 15 kg per person, inntil to ganger per kalenderår, og kuttes til 10 kg fra 2027. Slik fungerer reglene for turistfiskebedrifter og hva det betyr for gjestene dine."
 slug: "utforselskvote-fisk-2026"
 guid: "8b725c20-ef2f-4d28-8731-5a523c4523d7"
 pubDate: 2026-04-27T08:00:00.000Z
@@ -11,13 +11,13 @@ image:
   alt: "Utførselskvote for fisk i 2026: Slik er de nye reglene"
 ---
 
-Når gjestene dine pakker bilen for hjemreise, er utførselskvoten gjerne det siste spørsmålet de stiller. Og det er ofte da det haster mest å ha riktig svar. Fra 1. januar 2026 er kvoten 15 kg fisk per person per opphold — og den faller til 10 kg fra 1. januar 2027. For deg som driver [registrert turistfiskebedrift](/blogg/ma-du-registrere-turistfiskebedrift/) er det nødvendig å kjenne disse grensene, fordi det er du som utsteder dokumentasjonen gjestene trenger ved grensepassering.
+Når gjestene dine pakker bilen for hjemreise, er utførselskvoten gjerne det siste spørsmålet de stiller. Og det er ofte da det haster mest å ha riktig svar. Fra 1. januar 2026 er kvoten 15 kg fisk per person, inntil to ganger per kalenderår, og den faller til 10 kg fra 1. januar 2027. For deg som driver [registrert turistfiskebedrift](/blogg/ma-du-registrere-turistfiskebedrift/) er det nødvendig å kjenne disse grensene, fordi det er du som utsteder dokumentasjonen gjestene trenger ved grensepassering.
 
 Reglene er hjemlet i FOR-2006-06-01-570 (forskrift om utførselsregulering av fisk og fiskevarer fra sportsfiske), senest endret ved FOR-2025-07-02-1401, som trådte i kraft 1. januar 2026.
 
 ## Hva er utførselskvoten i 2026?
 
-Fra 1. januar 2026 kan en person ta med seg inntil **15 kg fisk eller fiskevarer** ut av Norge. Kvoten gjelder per opphold, og den samme personen kan benytte seg av kvoten inntil to ganger i løpet av 2026.
+I 2026 kan turister som har fisket og oppholdt seg ved en registrert turistfiskebedrift, ta med inntil **15 kg fisk eller fiskeprodukter** ut av Norge per person, inntil to ganger per kalenderår. Fra 1. januar 2027 reduseres kvoten til 10 kg.
 
 Fra 1. januar 2027 kuttes kvoten til **10 kg**, to ganger per kalenderår. Det er denne trinnvise nedtrappingen myndighetene varslet da de første endringene ble vedtatt i 2025, og det er verdt å informere gjestene om allerede nå.
 


### PR DESCRIPTION
## Bakgrunn (audit-finding)

Tekst i blogginnlegg brukte \"per opphold\" om utførselskvoten. Offisiell formulering er \"per person, inntil to ganger per kalenderår\". \"Per opphold\" er korrekt kun i kontekst av fangstrapportering, ikke utførselskvote.

## Endringer

- `utforselskvote-fisk-2026.md`: description-felt og to avsnitt i brødtekst oppdatert til korrekt formulering
- `daglig-fangstrapportering-turistfiske.md`: kvoteparagraf presisert
- `trofefisk-fjernet-turistfiske.md`: \"per tur\" erstattet med \"per person, inntil to ganger per kalenderår\"

Fangstrapporterings-kontekster med \"per opphold og art\" er ikke endret, det er korrekt formulering.

## Test plan

- [ ] Kontroller `/blogg/utforselskvote-fisk-2026` at formulering er konsistent
- [ ] Kontroller `/blogg/daglig-fangstrapportering-turistfiske` avsnitt om utførselskvote
- [ ] Kontroller `/blogg/trofefisk-fjernet-turistfiske` avsnitt \"Hva er utførselskvoten nå?\"
- [ ] `npm run build` passerer (verifisert lokalt)