### PR TITLE
Konkretiser dokumentasjonskrav: ny seksjon om grensepassering

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -604,6 +604,32 @@ import sei from '../assets/sei.png';
     </div>
   </section>
 
+  <!-- Dokumentasjon ved grensepassering -->
+  <section class="py-16 px-4 bg-blue-50" id="dokumentasjon-grensepassering">
+    <div class="max-w-4xl mx-auto px-4">
+      <div class="text-center mb-8">
+        <div class="inline-flex items-center justify-center w-14 h-14 bg-blue-100 rounded-full mb-4">
+          <svg class="w-7 h-7 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+          </svg>
+        </div>
+        <h2 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">Dokumentasjon ved grensepassering</h2>
+      </div>
+      <div class="bg-white rounded-2xl shadow-md p-8 max-w-3xl mx-auto">
+        <p class="text-gray-700 text-lg leading-relaxed mb-4">
+          Når fangsten er rapportert, kan det utstedes eksportdokumentasjon for den enkelte turistfisker.
+          Dokumentasjonen bør kunne fremvises ved grensekontroll og knyttes til registrert turistfiskebedrift,
+          personen som har fisket, og rapportert fangst.
+        </p>
+        <p class="text-gray-700 leading-relaxed">
+          I export.fish-appen skjer dette i det siste steget av fiskeperioden: når alle fangstdager er registrert
+          og perioden er godkjent av bedriften, genereres eksportdokumentene automatisk, ett per person.
+          Gjestene mottar dokumentet digitalt og kan vise det frem ved grensepassering uten å ha papir med seg.
+        </p>
+      </div>
+    </div>
+  </section>
+
   <!-- FAQ Section -->
   <section class="py-20 px-4 bg-gray-50">
     <div class="max-w-6xl mx-auto px-4">


### PR DESCRIPTION
## Bakgrunn (audit-finding)

Siden sa at appen utsteder dokumentasjon automatisk, men forklarte ikke hva den inneholder, når den utstedes, eller hvem den utstedes til. Potensielle kunder og Fiskeridirektoratet forventer at dette er tydelig kommunisert.

## Endringer

- `src/pages/index.astro`: ny seksjon \"Dokumentasjon ved grensepassering\" lagt til mellom Compliance-seksjonen og FAQ. Seksjonen forklarer at dokumentasjonen knyttes til registrert turistfiskebedrift, personen som fisket, og rapportert fangst, og beskriver kortfattet hvor i appen dette skjer (siste steg i fiskeperioden).

## Test plan

- [ ] Kontroller at ny seksjon vises korrekt på forsiden mellom lovkrav-seksjonen og FAQ
- [ ] Sjekk at ID `dokumentasjon-grensepassering` fungerer som anker-lenke
- [ ] Kontroller mobilvisning (maks 4xl container, padding)
- [ ] `npm run build` passerer (verifisert lokalt)