### PR TITLE
Løft godkjent fagsystem høyere i hero

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -31,6 +31,14 @@ import sei from '../assets/sei.png';
     </div>
 
     <div class="w-full mx-auto text-center max-w-5xl relative z-10 px-4">
+      <!-- Trust Signal Badge — visible before headline -->
+      <div class="mb-5 inline-flex items-center gap-2 bg-green-500/20 border border-green-400/40 rounded-full px-4 py-2">
+        <svg class="w-5 h-5 text-green-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path>
+        </svg>
+        <span class="text-sm font-semibold text-green-100">Godkjent fagsystem for fangstrapportering til Fiskeridirektoratet</span>
+      </div>
+
       <h1 class="text-4xl md:text-7xl font-bold mb-6 leading-tight break-words" id="hero-heading">
         Leier du ut <span
           id="hero-word"
@@ -39,16 +47,8 @@ import sei from '../assets/sei.png';
       </h1>
 
       <p class="text-xl md:text-2xl mb-10 max-w-3xl mx-auto text-blue-50 font-light leading-relaxed">
-        Da må du rapportere fangst til Fiskeridirektoratet. Vi gjør det enkelt – turistene registrerer selv på sitt språk.
+        Digital rapportering og eksportdokumentasjon for registrerte turistfiskebedrifter. Turistene registrerer selv på sitt språk.
       </p>
-
-      <!-- Trust Signal Badge -->
-      <div class="mb-6 inline-flex items-center gap-2 bg-green-500/20 border border-green-400/40 rounded-full px-4 py-2">
-        <svg class="w-5 h-5 text-green-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path>
-        </svg>
-        <span class="text-sm font-semibold text-green-100">Godkjent rapporteringssystem fra Fiskeridirektoratet</span>
-      </div>
 
       <div class="mb-8 flex flex-wrap justify-center gap-6 text-sm text-blue-100">
         <div class="flex items-center gap-2">


### PR DESCRIPTION
## Bakgrunn (audit-finding)

Sterkeste tillitsbeviset (godkjent av Fiskeridirektoratet) kom etter overskriften. Første-inntrykket for regelverksstressede utleiere bør være autoritetssignalet, ikke spørsmålet.

## Endringer

- `src/pages/index.astro`: Trust-badge flyttet over h1 i hero-seksjonen
- Badge-tekst endret fra \"Godkjent rapporteringssystem fra Fiskeridirektoratet\" til \"Godkjent fagsystem for fangstrapportering til Fiskeridirektoratet\" (mer autoritativt, samsvarer med fagsystem-begrep)
- Hero-ingress oppdatert til \"Digital rapportering og eksportdokumentasjon for registrerte turistfiskebedrifter\" for å speile fagsystem-temaet

## Test plan

- [ ] Kontroller at badge vises over h1 i hero på forsiden
- [ ] Sjekk at animert hero-ord (hytta/rorbua/båten) fortsatt fungerer
- [ ] Kontroller mobilvisning
- [ ] `npm run build` passerer (verifisert lokalt)