### PR TITLE
Presiser registreringsplikt: tre tydelige niva

### DIFF
--- a/src/pages/registrering.astro
+++ b/src/pages/registrering.astro
@@ -73,10 +73,17 @@ import Layout from '../layouts/Layout.astro';
             </p>
 
             <div class="bg-slate-50 border-l-4 border-orange-400 rounded-lg p-6 mb-6">
-              <p class="text-gray-900 font-semibold mb-1">Godt å vite:</p>
+              <p class="text-gray-900 font-semibold mb-2">Hvem må registrere?</p>
+              <p class="text-gray-700 mb-3">
+                Registrering er lovpålagt hvis alle tre vilkår er oppfylt: du er MVA-registrert, bruttoinntekten fra virksomheten er minst 50 000 kr per år, og du har båt tilgjengelig for gjestene.
+              </p>
+              <p class="text-gray-900 font-semibold mb-2">Hvem kan registrere frivillig?</p>
+              <p class="text-gray-700 mb-3">
+                Har du organisasjonsnummer (et ENK er nok) og båt, kan du registrere deg frivillig selv om du ikke oppfyller alle tre krav. Frivillig registrering gir gjestene utførselskvote og gjør deg mer attraktiv for utenlandske gjester.
+              </p>
+              <p class="text-gray-900 font-semibold mb-2">Når får gjester ikke utførselskvote?</p>
               <p class="text-gray-700">
-                Alle som leier ut til turistfiske må rapportere, også fritidsboligeiere som kun leier ut noen få uker i året.
-                Regelverket er tydelig: Utleie mot betaling kombinert med fiske gir rapporteringsplikt – dette gjelder også norske gjester, ikke bare utenlandske.
+                Gjester som bor hos en uregistrert virksomhet får ingen utførselskvote og kan ikke ta med fisk ut av Norge, uavhengig av nasjonalitet. Se <a href="/blogg/ma-du-registrere-turistfiskebedrift/" class="text-blue-600 hover:text-blue-800 underline">vår guide om registreringsplikt</a> for en fullstendig gjennomgang.
               </p>
             </div>
 


### PR DESCRIPTION
## Bakgrunn (audit-finding)

Formulering \"Alle som leier ut til turistfiske må rapportere\" er for bred. Regelverket skiller mellom pliktig registrering, frivillig registrering og ingen registrering. For bastante formuleringer kan misinformere utleiere.

## Endringer

- `src/pages/registrering.astro`: \"Godt å vite\"-boksen i quiz-resultatet presiserer nå tre nivåer:
  1. Virksomheter som er pliktige (MVA-registrert, over 50 000 kr, har båt)
  2. Virksomheter som kan registrere seg frivillig (organisasjonsnummer og båt)
  3. Situasjoner der gjester ikke får utførselskvote (uregistrert vertskap)
- Lenke til bloggartikkel om registreringsplikt lagt inn

## Test plan

- [ ] Gå gjennom quiz-flyten på `/registrering` og kontroller at \"Ja\"-resultatet viser de tre nivåene tydelig
- [ ] Kontroller at lenke til bloggartikkel om registreringsplikt fungerer
- [ ] `npm run build` passerer (verifisert lokalt)