### PR TITLE
Legg til personvernerklaring og footer-lenker

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -70,6 +70,16 @@ import logo from '../assets/logo.png';
               Kontaktinformasjon
             </a>
           </li>
+          <li>
+            <a href="/personvern" class="hover:text-primary transition text-gray-400">
+              Personvernerklæring
+            </a>
+          </li>
+          <li>
+            <a href="/vilkar" class="hover:text-primary transition text-gray-400">
+              Vilkår for bruk
+            </a>
+          </li>
         </ul>
       </div>
     </div>

--- a/src/content/legal/personvern.md
+++ b/src/content/legal/personvern.md
@@ -1,8 +1,8 @@
 # Personvernerklæring for eksportfiske.no
 
-Denne personvernerklæringen beskriver hvordan vi behandler personopplysninger samlet inn via markedsføringssiden eksportfiske.no, inkludert skjemainnsendinger og analyseinformasjon. Behandlingsansvarlig er Eksportfiske.no (EIK IT, org.nr. 993981532).
+Denne personvernerklæringen beskriver hvordan vi behandler personopplysninger om **turistfiskebedrifter** (kunder) i forbindelse med eksportfiske.no og det tilhørende abonnementet på export.fish-tjenesten. Behandlingsansvarlig er Eksportfiske.no (EIK IT, org.nr. 993981532).
 
-**Relatert:** Rapporteringstjenesten export.fish har sin egen [personvernerklæring](https://export.fish/privacy) og [vilkår](https://export.fish/terms) som dekker turistens og fiskerens bruk av PWA-en (fangstdata, eksportdokumenter osv.). Denne erklæringen omhandler kun det som skjer på eksportfiske.no og det som videreformidles til våre systemer som følge av registrering.
+**Avgrensning:** Selve rapporteringsverktøyet export.fish har egen [personvernerklæring](https://export.fish/privacy) og [vilkår](https://export.fish/terms) som dekker personopplysninger om **turister og fiskere** (sluttbrukere som registrerer fangst). Bedriftsdata og turistdata lagres i samme backend-database, men har ulike behandlingsansvarlige og dekkes derfor av hver sin erklæring.
 
 ## 1. Behandlingsansvarlig
 
@@ -12,16 +12,16 @@ Kontakt: [kontakt@eksportfiske.no](mailto:kontakt@eksportfiske.no)
 
 ## 2. Hvilke opplysninger samles inn
 
-Eksportfiske.no behandler følgende kategorier opplysninger:
+Vi behandler følgende kategorier personopplysninger om turistfiskebedrifter:
 
-### 2.1 Skjemainnsendinger
-Når du fyller ut registreringsskjema eller kontaktforespørsel på siden, samler vi inn opplysningene du selv oppgir, typisk:
+### 2.1 Bedriftsdata (kontoinformasjon)
+Ved registrering og bruk av export.fish-tjenesten samler vi inn:
 - Bedriftsnavn og organisasjonsnummer
-- Kontaktperson og e-postadresse
+- Navn på kontaktperson
+- E-postadresse (driftskontakt)
 - Telefonnummer
-- Andre opplysninger du frivillig deler i meldingsfelt
-
-Disse opplysningene brukes til å besvare henvendelsen din og starte registreringsprosessen for et export.fish-abonnement. Lagring og videre behandling skjer i våre egne backend-systemer (export.fish API) under samme behandlingsansvar.
+- Håndskreven signatur (brukes ved utstedelse av utførselsdokumentasjon på vegne av bedriften)
+- Annen informasjon du frivillig deler ved henvendelse eller registrering
 
 ### 2.2 Tekniske data og bruk av siden
 - Standard nettleserdata (IP-adresse, nettlesertype, besøkte sider) når du har gitt samtykke til analyseverktøy
@@ -53,6 +53,9 @@ Følgende underleverandører behandler personopplysninger i forbindelse med drif
 
 | Underleverandør | Tjeneste | Dataoverføring |
 |---|---|---|
+| Google Cloud Platform (GCP) | Skyhosting og infrastruktur for backend | EU-region |
+| Supabase | Database og autentisering | EU-region |
+| Mailgun | Transaksjonell e-post (fakturering, varsler) | EU-region |
 | Google LLC | Google Analytics (kun etter samtykke) | USA, EU-US Data Privacy Framework |
 | Meta Platforms Inc. | Meta Pixel (kun etter samtykke) | USA, EU-US Data Privacy Framework |
 
@@ -62,8 +65,10 @@ Hver av leverandørene har egne databehandleravtaler og personvernerklæringer s
 
 | Type data | Lagringstid |
 |---|---|
+| Bedriftsdata (aktiv konto) | Lagres så lenge kontoen er aktiv |
+| Bedriftsdata (avsluttet konto) | Lagres permanent |
+| Håndskreven signatur | Lagres så lenge bedriften har behov for utstedelse av utførselsdokumentasjon; slettes ved skriftlig forespørsel |
 | Samtykkevalg (`cookie-consent`) | Lagres i nettleseren din til du sletter den manuelt |
-| Skjemainnsendinger | Lagres permanent i våre systemer som del av kundeforholdet |
 | Analyseinformasjon (Google Analytics) | I henhold til Google Analytics standard (14 måneder med mindre vi justerer ned) |
 
 ## 7. Sikkerhetstiltak

--- a/src/content/legal/personvern.md
+++ b/src/content/legal/personvern.md
@@ -55,7 +55,8 @@ Følgende underleverandører behandler personopplysninger i forbindelse med drif
 |---|---|---|
 | Google Cloud Platform (GCP) | Skyhosting og infrastruktur for backend | EU-region |
 | Supabase | Database og autentisering | EU-region |
-| Mailgun | Transaksjonell e-post (fakturering, varsler) | EU-region |
+| Mailgun | Transaksjonell e-post (varsler) | EU-region |
+| Fiken | Fakturering og regnskap (kundedata, fakturadata) | Norge |
 | Google LLC | Google Analytics (kun etter samtykke) | USA, EU-US Data Privacy Framework |
 | Meta Platforms Inc. | Meta Pixel (kun etter samtykke) | USA, EU-US Data Privacy Framework |
 

--- a/src/content/legal/personvern.md
+++ b/src/content/legal/personvern.md
@@ -1,7 +1,5 @@
 # Personvernerklæring for export.fish
 
-Sist oppdatert: mai 2026
-
 Denne personvernerklæringen beskriver hvordan Eksportfiske.no (EIK IT, org.nr. 993981532) behandler personopplysninger i forbindelse med tjenesten export.fish.
 
 ## 1. Behandlingsansvarlig og databehandler
@@ -48,10 +46,10 @@ Opplysningene benyttes til:
 
 | Type data | Lagringstid |
 |---|---|
-| Fangstdata og rapporter | Minimum 5 år (lovpålagt arkivplikt) |
-| Bedriftsdata (aktiv konto) | Til kontoen avsluttes |
-| Bedriftsdata (avsluttet konto) | 3 år etter oppsigelse |
-| Tekniske logger | 90 dager |
+| Fangstdata og rapporter | Lagres permanent som referansegrunnlag og dokumentasjon |
+| Bedriftsdata (aktiv konto) | Lagres så lenge kontoen er aktiv |
+| Bedriftsdata (avsluttet konto) | Lagres permanent |
+| Tekniske logger | I henhold til standard retensjon hos Google Cloud Platform; vi sletter ikke logger aktivt |
 
 ## 6. Deling av data
 
@@ -63,10 +61,11 @@ Vi benytter følgende underleverandører som behandler personopplysninger på v�
 
 | Underleverandør | Tjeneste | Dataoverføring |
 |---|---|---|
-| [Hosting-leverandør — oppdateres av behandlingsansvarlig] | Skyhosting og database | Innenfor EØS |
-| [E-postleverandør — oppdateres av behandlingsansvarlig] | Transaksjonell e-post | Innenfor EØS |
+| Google Cloud Platform (GCP) | Skyhosting og infrastruktur | EU-region |
+| Supabase | Database og autentisering | EU-region |
+| Mailgun | Transaksjonell e-post | EU-region |
 
-Alle underleverandører er bundet av databehandleravtale og behandler kun data i samsvar med våre instrukser.
+Hver av leverandørene har egne databehandleravtaler og personvernerklæringer som regulerer deres behandling av personopplysninger. Vi henviser til hver leverandørs vilkår for fullstendige detaljer.
 
 ## 8. Databehandleravtale
 

--- a/src/content/legal/personvern.md
+++ b/src/content/legal/personvern.md
@@ -1,8 +1,8 @@
 # Personvernerklæring for eksportfiske.no
 
-Denne personvernerklæringen beskriver hvordan markedsføringssiden eksportfiske.no behandler personopplysninger. Siden drives av Eksportfiske.no (EIK IT, org.nr. 993981532).
+Denne personvernerklæringen beskriver hvordan vi behandler personopplysninger samlet inn via markedsføringssiden eksportfiske.no, inkludert skjemainnsendinger og analyseinformasjon. Behandlingsansvarlig er Eksportfiske.no (EIK IT, org.nr. 993981532).
 
-**Merk:** Rapporteringstjenesten export.fish er en separat tjeneste med egen personvernerklæring og egne vilkår. Personopplysninger som behandles inne i export.fish (fangstdata, turistdata, dokumentutstedelse osv.) dekkes ikke av denne erklæringen, men av [export.fish sin personvernerklæring](https://export.fish/privacy) og [vilkår for bruk](https://export.fish/terms).
+**Relatert:** Rapporteringstjenesten export.fish har sin egen [personvernerklæring](https://export.fish/privacy) og [vilkår](https://export.fish/terms) som dekker turistens og fiskerens bruk av PWA-en (fangstdata, eksportdokumenter osv.). Denne erklæringen omhandler kun det som skjer på eksportfiske.no og det som videreformidles til våre systemer som følge av registrering.
 
 ## 1. Behandlingsansvarlig
 
@@ -21,7 +21,7 @@ Når du fyller ut registreringsskjema eller kontaktforespørsel på siden, samle
 - Telefonnummer
 - Andre opplysninger du frivillig deler i meldingsfelt
 
-Disse opplysningene videresendes til rapporteringstjenesten export.fish for videre behandling i henhold til [export.fish sin personvernerklæring](https://export.fish/privacy).
+Disse opplysningene brukes til å besvare henvendelsen din og starte registreringsprosessen for et export.fish-abonnement. Lagring og videre behandling skjer i våre egne backend-systemer (export.fish API) under samme behandlingsansvar.
 
 ### 2.2 Tekniske data og bruk av siden
 - Standard nettleserdata (IP-adresse, nettlesertype, besøkte sider) når du har gitt samtykke til analyseverktøy
@@ -53,31 +53,26 @@ Følgende underleverandører behandler personopplysninger i forbindelse med drif
 
 | Underleverandør | Tjeneste | Dataoverføring |
 |---|---|---|
-| GitHub, Inc. | Hosting av statisk nettside (GitHub Pages) | USA, EU-US Data Privacy Framework |
 | Google LLC | Google Analytics (kun etter samtykke) | USA, EU-US Data Privacy Framework |
 | Meta Platforms Inc. | Meta Pixel (kun etter samtykke) | USA, EU-US Data Privacy Framework |
 
 Hver av leverandørene har egne databehandleravtaler og personvernerklæringer som regulerer deres behandling av personopplysninger. Vi henviser til hver leverandørs vilkår for fullstendige detaljer.
 
-## 6. Videresending til export.fish
-
-Skjemainnsendinger fra eksportfiske.no videresendes direkte til API-et til rapporteringstjenesten export.fish. Eksportfiske.no lagrer ikke selv en kopi av innsendingen ut over det som måtte vises i nettleserloggen din. For hvordan opplysningene behandles videre, se [export.fish sin personvernerklæring](https://export.fish/privacy) og [vilkår](https://export.fish/terms).
-
-## 7. Lagringstid
+## 6. Lagringstid
 
 | Type data | Lagringstid |
 |---|---|
 | Samtykkevalg (`cookie-consent`) | Lagres i nettleseren din til du sletter den manuelt |
-| Skjemainnsendinger | Eksportfiske.no lagrer ingen kopi; videreformidles til export.fish |
+| Skjemainnsendinger | Lagres permanent i våre systemer som del av kundeforholdet |
 | Analyseinformasjon (Google Analytics) | I henhold til Google Analytics standard (14 måneder med mindre vi justerer ned) |
 
-## 8. Sikkerhetstiltak
+## 7. Sikkerhetstiltak
 
 - All trafikk til og fra siden krypteres med HTTPS/TLS
-- Statisk hosting via GitHub Pages med standard sikkerhetstiltak fra GitHub
-- Ingen brukerdatabaser eller sensitive datalagringer på selve siden
+- Statisk hosting med standard sikkerhetstiltak
+- Ingen brukerdatabaser eller sensitive datalagringer på selve markedsføringssiden; persistert data ligger i våre backend-systemer
 
-## 9. Dine rettigheter etter GDPR
+## 8. Dine rettigheter etter GDPR
 
 Som registrert har du følgende rettigheter:
 
@@ -91,7 +86,7 @@ For å benytte dine rettigheter, kontakt oss på [kontakt@eksportfiske.no](mailt
 
 Du har også rett til å klage til **Datatilsynet** hvis du mener behandlingen er i strid med personvernregelverket: [datatilsynet.no](https://www.datatilsynet.no).
 
-## 10. Kontaktinformasjon for personvern
+## 9. Kontaktinformasjon for personvern
 
 For alle spørsmål om personvern og behandling av personopplysninger på eksportfiske.no:
 

--- a/src/content/legal/personvern.md
+++ b/src/content/legal/personvern.md
@@ -1,0 +1,115 @@
+# Personvernerklæring for export.fish
+
+Sist oppdatert: mai 2026
+
+Denne personvernerklæringen beskriver hvordan Eksportfiske.no (EIK IT, org.nr. 993981532) behandler personopplysninger i forbindelse med tjenesten export.fish.
+
+## 1. Behandlingsansvarlig og databehandler
+
+**Behandlingsansvarlig** for turistfiskebedriftens kontaktinformasjon og virksomhetsdata er turistfiskebedriften selv.
+
+**Databehandler** for fangstdata og rapporteringsdata er Eksportfiske.no (EIK IT). Vi behandler disse dataene på vegne av turistfiskebedriften i henhold til databehandleravtale (se punkt 8).
+
+For spørsmål om behandlingen, kontakt oss på [kontakt@eksportfiske.no](mailto:kontakt@eksportfiske.no).
+
+## 2. Behandlingsgrunnlag
+
+Personopplysninger behandles på følgende grunnlag etter GDPR art. 6:
+
+- **Art. 6 (1) c — rettslig forpliktelse**: Fangstdata behandles for å oppfylle rapporteringsplikt etter forskrift 20. desember 2017 nr. 2445 om rapportering av fangster fra turistfiskevirksomheter.
+- **Art. 6 (1) b — oppfyllelse av avtale**: Kontaktopplysninger og bedriftsdata behandles for å levere tjenesten i henhold til inngåtte vilkår.
+- **Art. 6 (1) f — berettiget interesse**: Teknisk logging og sikkerhetstiltak for å beskytte tjenestens integritet.
+
+## 3. Hvilke opplysninger behandles
+
+### 3.1 Turistfiskebedriftens data
+- Navn og kontaktperson
+- Organisasjonsnummer
+- E-postadresse (driftskontakt)
+- Håndskreven signatur (benyttes ved utstedelse av utførselsdokumentasjon)
+
+### 3.2 Turistdata
+- E-postadresse (for tilgangskontroll til rapporteringsapp)
+- Fangstdata per dag: art, antall, dato, fiskeperiode
+
+### 3.3 Tekniske data
+- IP-adresse og nettleserinformasjon (sikkerhet og feilsøking)
+- Innloggingstidspunkter og aktivitetslogg
+
+## 4. Formål med behandlingen
+
+Opplysningene benyttes til:
+- Daglig rapportering av fangstdata til Fiskeridirektoratet
+- Utstedelse av eksportdokumentasjon for turistene
+- Fakturering og kontraktshåndtering
+- Support og kommunikasjon med registrerte bedrifter
+
+## 5. Lagringstid
+
+| Type data | Lagringstid |
+|---|---|
+| Fangstdata og rapporter | Minimum 5 år (lovpålagt arkivplikt) |
+| Bedriftsdata (aktiv konto) | Til kontoen avsluttes |
+| Bedriftsdata (avsluttet konto) | 3 år etter oppsigelse |
+| Tekniske logger | 90 dager |
+
+## 6. Deling av data
+
+Fangstdata rapporteres automatisk til **Fiskeridirektoratet** i henhold til lovkrav. Data deles ikke med andre tredjeparter uten ditt eksplisitte samtykke, med unntak av underleverandørene beskrevet i punkt 7.
+
+## 7. Underleverandører (databehandlere)
+
+Vi benytter følgende underleverandører som behandler personopplysninger på våre vegne:
+
+| Underleverandør | Tjeneste | Dataoverføring |
+|---|---|---|
+| [Hosting-leverandør — oppdateres av behandlingsansvarlig] | Skyhosting og database | Innenfor EØS |
+| [E-postleverandør — oppdateres av behandlingsansvarlig] | Transaksjonell e-post | Innenfor EØS |
+
+Alle underleverandører er bundet av databehandleravtale og behandler kun data i samsvar med våre instrukser.
+
+## 8. Databehandleravtale
+
+Som databehandler for fangstdata inngår vi databehandleravtale med alle registrerte turistfiskebedrifter. Avtalen regulerer:
+- Formål og omfang for behandlingen
+- Sikkerhetskrav og konfidensialitet
+- Turistfiskebedriftens instruksjonsrett
+- Rutiner ved brudd på personopplysningssikkerheten
+
+Databehandleravtalen er en del av vilkårene du aksepterte ved registrering. Ta kontakt på [kontakt@eksportfiske.no](mailto:kontakt@eksportfiske.no) hvis du ønsker en kopi.
+
+## 9. Sikkerhetstiltak
+
+Vi benytter følgende tekniske og organisatoriske tiltak for å beskytte personopplysningene:
+- Kryptert overføring (HTTPS/TLS) for all kommunikasjon
+- Kryptert lagring av sensitiv data i databasen
+- Tilgangskontroll: kun autorisert personell har tilgang til produksjonsdata
+- Regelmessige sikkerhetsvurderinger
+- Automatiske varsler ved uvanlig aktivitet
+
+## 10. Dine rettigheter etter GDPR
+
+Som registrert har du følgende rettigheter:
+
+- **Innsyn (art. 15)**: Du kan be om innsyn i hvilke opplysninger vi har om deg.
+- **Retting (art. 16)**: Du kan be om at uriktige opplysninger rettes.
+- **Sletting (art. 17)**: Du kan be om sletting av opplysninger der det ikke foreligger lovpålagt lagringsplikt.
+- **Dataportabilitet (art. 20)**: Du kan be om å få utlevert dine data i maskinlesbart format.
+- **Innsigelse (art. 21)**: Du kan protestere mot behandling basert på berettiget interesse.
+
+For å benytte dine rettigheter, kontakt oss på [kontakt@eksportfiske.no](mailto:kontakt@eksportfiske.no). Vi vil svare innen 30 dager.
+
+Du har også rett til å klage til **Datatilsynet** hvis du mener behandlingen er i strid med personvernregelverket: [datatilsynet.no](https://www.datatilsynet.no).
+
+## 11. Informasjonskapsler
+
+Export.fish bruker nødvendige informasjonskapsler for innlogging og sesjonshåndtering. Vi bruker ikke sporings- eller reklamekapsler uten ditt samtykke. Se vår [cookieinformasjon](#informasjonskapsler) for detaljer.
+
+## 12. Kontaktinformasjon for personvern
+
+For alle spørsmål om personvern og behandling av personopplysninger:
+
+**E-post**: [kontakt@eksportfiske.no](mailto:kontakt@eksportfiske.no)
+
+**Organisasjon**: EIK IT  
+**Organisasjonsnummer**: 993981532

--- a/src/content/legal/personvern.md
+++ b/src/content/legal/personvern.md
@@ -65,8 +65,7 @@ Hver av leverandørene har egne databehandleravtaler og personvernerklæringer s
 
 | Type data | Lagringstid |
 |---|---|
-| Bedriftsdata (aktiv konto) | Lagres så lenge kontoen er aktiv |
-| Bedriftsdata (avsluttet konto) | Lagres permanent |
+| Bedriftsdata | Lagres permanent |
 | Håndskreven signatur | Lagres så lenge bedriften har behov for utstedelse av utførselsdokumentasjon; slettes ved skriftlig forespørsel |
 | Samtykkevalg (`cookie-consent`) | Lagres i nettleseren din til du sletter den manuelt |
 | Analyseinformasjon (Google Analytics) | I henhold til Google Analytics standard (14 måneder med mindre vi justerer ned) |

--- a/src/content/legal/personvern.md
+++ b/src/content/legal/personvern.md
@@ -64,6 +64,8 @@ Vi benytter følgende underleverandører som behandler personopplysninger på v�
 | Google Cloud Platform (GCP) | Skyhosting og infrastruktur | EU-region |
 | Supabase | Database og autentisering | EU-region |
 | Mailgun | Transaksjonell e-post | EU-region |
+| Google LLC | Google Analytics (kun etter samtykke) | USA, EU-US Data Privacy Framework |
+| Meta Platforms Inc. | Meta Pixel (kun etter samtykke) | USA, EU-US Data Privacy Framework |
 
 Hver av leverandørene har egne databehandleravtaler og personvernerklæringer som regulerer deres behandling av personopplysninger. Vi henviser til hver leverandørs vilkår for fullstendige detaljer.
 
@@ -102,7 +104,20 @@ Du har også rett til å klage til **Datatilsynet** hvis du mener behandlingen e
 
 ## 11. Informasjonskapsler
 
-Export.fish bruker nødvendige informasjonskapsler for innlogging og sesjonshåndtering. Vi bruker ikke sporings- eller reklamekapsler uten ditt samtykke. Se vår [cookieinformasjon](#informasjonskapsler) for detaljer.
+Export.fish bruker informasjonskapsler i to kategorier:
+
+**Strengt nødvendige (uten samtykke):**
+- Innloggings- og sesjonsinformasjon
+- Lagring av ditt samtykkevalg (`cookie-consent` i nettleserens localStorage)
+
+**Analyse og markedsføring (kun etter samtykke):**
+Når du klikker "Godta" i cookie-banneret, aktiveres:
+- **Google Analytics** for å forstå hvordan siden brukes
+- **Meta Pixel** for å måle effekten av annonsering på Facebook og Instagram
+
+Vi bruker Google Consent Mode v2, som betyr at all analyse og markedsføring er deaktivert som standard inntil du gir samtykke. Du kan trekke tilbake samtykket når som helst ved å slette `cookie-consent` fra nettleserens localStorage, eller bruke nettleserens funksjon for å slette informasjonskapsler for siden.
+
+Begge analysetjenestene overfører data til USA. Overføringen skjer i henhold til EU-US Data Privacy Framework (DPF), som er en godkjent overføringsmekanisme etter GDPR.
 
 ## 12. Kontaktinformasjon for personvern
 

--- a/src/content/legal/personvern.md
+++ b/src/content/legal/personvern.md
@@ -1,113 +1,43 @@
-# Personvernerklæring for export.fish
+# Personvernerklæring for eksportfiske.no
 
-Denne personvernerklæringen beskriver hvordan Eksportfiske.no (EIK IT, org.nr. 993981532) behandler personopplysninger i forbindelse med tjenesten export.fish.
+Denne personvernerklæringen beskriver hvordan markedsføringssiden eksportfiske.no behandler personopplysninger. Siden drives av Eksportfiske.no (EIK IT, org.nr. 993981532).
 
-## 1. Behandlingsansvarlig og databehandler
+**Merk:** Rapporteringstjenesten export.fish er en separat tjeneste med egen personvernerklæring og egne vilkår. Personopplysninger som behandles inne i export.fish (fangstdata, turistdata, dokumentutstedelse osv.) dekkes ikke av denne erklæringen, men av [export.fish sin personvernerklæring](https://export.fish/privacy) og [vilkår for bruk](https://export.fish/terms).
 
-**Behandlingsansvarlig** for turistfiskebedriftens kontaktinformasjon og virksomhetsdata er turistfiskebedriften selv.
+## 1. Behandlingsansvarlig
 
-**Databehandler** for fangstdata og rapporteringsdata er Eksportfiske.no (EIK IT). Vi behandler disse dataene på vegne av turistfiskebedriften i henhold til databehandleravtale (se punkt 8).
+Eksportfiske.no (EIK IT, org.nr. 993981532) er behandlingsansvarlig for personopplysninger som samles inn via eksportfiske.no.
 
-For spørsmål om behandlingen, kontakt oss på [kontakt@eksportfiske.no](mailto:kontakt@eksportfiske.no).
+Kontakt: [kontakt@eksportfiske.no](mailto:kontakt@eksportfiske.no)
 
-## 2. Behandlingsgrunnlag
+## 2. Hvilke opplysninger samles inn
 
-Personopplysninger behandles på følgende grunnlag etter GDPR art. 6:
+Eksportfiske.no behandler følgende kategorier opplysninger:
 
-- **Art. 6 (1) c — rettslig forpliktelse**: Fangstdata behandles for å oppfylle rapporteringsplikt etter forskrift 20. desember 2017 nr. 2445 om rapportering av fangster fra turistfiskevirksomheter.
-- **Art. 6 (1) b — oppfyllelse av avtale**: Kontaktopplysninger og bedriftsdata behandles for å levere tjenesten i henhold til inngåtte vilkår.
-- **Art. 6 (1) f — berettiget interesse**: Teknisk logging og sikkerhetstiltak for å beskytte tjenestens integritet.
+### 2.1 Skjemainnsendinger
+Når du fyller ut registreringsskjema eller kontaktforespørsel på siden, samler vi inn opplysningene du selv oppgir, typisk:
+- Bedriftsnavn og organisasjonsnummer
+- Kontaktperson og e-postadresse
+- Telefonnummer
+- Andre opplysninger du frivillig deler i meldingsfelt
 
-## 3. Hvilke opplysninger behandles
+Disse opplysningene videresendes til rapporteringstjenesten export.fish for videre behandling i henhold til [export.fish sin personvernerklæring](https://export.fish/privacy).
 
-### 3.1 Turistfiskebedriftens data
-- Navn og kontaktperson
-- Organisasjonsnummer
-- E-postadresse (driftskontakt)
-- Håndskreven signatur (benyttes ved utstedelse av utførselsdokumentasjon)
+### 2.2 Tekniske data og bruk av siden
+- Standard nettleserdata (IP-adresse, nettlesertype, besøkte sider) når du har gitt samtykke til analyseverktøy
+- Lagring av ditt samtykkevalg i nettleserens localStorage (`cookie-consent`)
 
-### 3.2 Turistdata
-- E-postadresse (for tilgangskontroll til rapporteringsapp)
-- Fangstdata per dag: art, antall, dato, fiskeperiode
+## 3. Behandlingsgrunnlag
 
-### 3.3 Tekniske data
-- IP-adresse og nettleserinformasjon (sikkerhet og feilsøking)
-- Innloggingstidspunkter og aktivitetslogg
+- **Art. 6 (1) b — oppfyllelse av avtale / forespørsel:** Skjemainnsendinger behandles for å besvare henvendelsen din eller starte registreringsprosessen.
+- **Art. 6 (1) a — samtykke:** Analyse- og markedsføringskapsler aktiveres kun etter eksplisitt samtykke via cookie-banneret.
+- **Art. 6 (1) f — berettiget interesse:** Drift, sikkerhet og feilsøking av nettsiden.
 
-## 4. Formål med behandlingen
+## 4. Informasjonskapsler og sporing
 
-Opplysningene benyttes til:
-- Daglig rapportering av fangstdata til Fiskeridirektoratet
-- Utstedelse av eksportdokumentasjon for turistene
-- Fakturering og kontraktshåndtering
-- Support og kommunikasjon med registrerte bedrifter
-
-## 5. Lagringstid
-
-| Type data | Lagringstid |
-|---|---|
-| Fangstdata og rapporter | Lagres permanent som referansegrunnlag og dokumentasjon |
-| Bedriftsdata (aktiv konto) | Lagres så lenge kontoen er aktiv |
-| Bedriftsdata (avsluttet konto) | Lagres permanent |
-| Tekniske logger | I henhold til standard retensjon hos Google Cloud Platform; vi sletter ikke logger aktivt |
-
-## 6. Deling av data
-
-Fangstdata rapporteres automatisk til **Fiskeridirektoratet** i henhold til lovkrav. Data deles ikke med andre tredjeparter uten ditt eksplisitte samtykke, med unntak av underleverandørene beskrevet i punkt 7.
-
-## 7. Underleverandører (databehandlere)
-
-Vi benytter følgende underleverandører som behandler personopplysninger på våre vegne:
-
-| Underleverandør | Tjeneste | Dataoverføring |
-|---|---|---|
-| Google Cloud Platform (GCP) | Skyhosting og infrastruktur | EU-region |
-| Supabase | Database og autentisering | EU-region |
-| Mailgun | Transaksjonell e-post | EU-region |
-| Google LLC | Google Analytics (kun etter samtykke) | USA, EU-US Data Privacy Framework |
-| Meta Platforms Inc. | Meta Pixel (kun etter samtykke) | USA, EU-US Data Privacy Framework |
-
-Hver av leverandørene har egne databehandleravtaler og personvernerklæringer som regulerer deres behandling av personopplysninger. Vi henviser til hver leverandørs vilkår for fullstendige detaljer.
-
-## 8. Databehandleravtale
-
-Som databehandler for fangstdata inngår vi databehandleravtale med alle registrerte turistfiskebedrifter. Avtalen regulerer:
-- Formål og omfang for behandlingen
-- Sikkerhetskrav og konfidensialitet
-- Turistfiskebedriftens instruksjonsrett
-- Rutiner ved brudd på personopplysningssikkerheten
-
-Databehandleravtalen er en del av vilkårene du aksepterte ved registrering. Ta kontakt på [kontakt@eksportfiske.no](mailto:kontakt@eksportfiske.no) hvis du ønsker en kopi.
-
-## 9. Sikkerhetstiltak
-
-Vi benytter følgende tekniske og organisatoriske tiltak for å beskytte personopplysningene:
-- Kryptert overføring (HTTPS/TLS) for all kommunikasjon
-- Kryptert lagring av sensitiv data i databasen
-- Tilgangskontroll: kun autorisert personell har tilgang til produksjonsdata
-- Regelmessige sikkerhetsvurderinger
-- Automatiske varsler ved uvanlig aktivitet
-
-## 10. Dine rettigheter etter GDPR
-
-Som registrert har du følgende rettigheter:
-
-- **Innsyn (art. 15)**: Du kan be om innsyn i hvilke opplysninger vi har om deg.
-- **Retting (art. 16)**: Du kan be om at uriktige opplysninger rettes.
-- **Sletting (art. 17)**: Du kan be om sletting av opplysninger der det ikke foreligger lovpålagt lagringsplikt.
-- **Dataportabilitet (art. 20)**: Du kan be om å få utlevert dine data i maskinlesbart format.
-- **Innsigelse (art. 21)**: Du kan protestere mot behandling basert på berettiget interesse.
-
-For å benytte dine rettigheter, kontakt oss på [kontakt@eksportfiske.no](mailto:kontakt@eksportfiske.no). Vi vil svare innen 30 dager.
-
-Du har også rett til å klage til **Datatilsynet** hvis du mener behandlingen er i strid med personvernregelverket: [datatilsynet.no](https://www.datatilsynet.no).
-
-## 11. Informasjonskapsler
-
-Export.fish bruker informasjonskapsler i to kategorier:
+Eksportfiske.no bruker informasjonskapsler i to kategorier:
 
 **Strengt nødvendige (uten samtykke):**
-- Innloggings- og sesjonsinformasjon
 - Lagring av ditt samtykkevalg (`cookie-consent` i nettleserens localStorage)
 
 **Analyse og markedsføring (kun etter samtykke):**
@@ -117,13 +47,55 @@ Når du klikker "Godta" i cookie-banneret, aktiveres:
 
 Vi bruker Google Consent Mode v2, som betyr at all analyse og markedsføring er deaktivert som standard inntil du gir samtykke. Du kan trekke tilbake samtykket når som helst ved å slette `cookie-consent` fra nettleserens localStorage, eller bruke nettleserens funksjon for å slette informasjonskapsler for siden.
 
-Begge analysetjenestene overfører data til USA. Overføringen skjer i henhold til EU-US Data Privacy Framework (DPF), som er en godkjent overføringsmekanisme etter GDPR.
+## 5. Underleverandører
 
-## 12. Kontaktinformasjon for personvern
+Følgende underleverandører behandler personopplysninger i forbindelse med driften av eksportfiske.no:
 
-For alle spørsmål om personvern og behandling av personopplysninger:
+| Underleverandør | Tjeneste | Dataoverføring |
+|---|---|---|
+| GitHub, Inc. | Hosting av statisk nettside (GitHub Pages) | USA, EU-US Data Privacy Framework |
+| Google LLC | Google Analytics (kun etter samtykke) | USA, EU-US Data Privacy Framework |
+| Meta Platforms Inc. | Meta Pixel (kun etter samtykke) | USA, EU-US Data Privacy Framework |
 
-**E-post**: [kontakt@eksportfiske.no](mailto:kontakt@eksportfiske.no)
+Hver av leverandørene har egne databehandleravtaler og personvernerklæringer som regulerer deres behandling av personopplysninger. Vi henviser til hver leverandørs vilkår for fullstendige detaljer.
 
-**Organisasjon**: EIK IT  
-**Organisasjonsnummer**: 993981532
+## 6. Videresending til export.fish
+
+Skjemainnsendinger fra eksportfiske.no videresendes direkte til API-et til rapporteringstjenesten export.fish. Eksportfiske.no lagrer ikke selv en kopi av innsendingen ut over det som måtte vises i nettleserloggen din. For hvordan opplysningene behandles videre, se [export.fish sin personvernerklæring](https://export.fish/privacy) og [vilkår](https://export.fish/terms).
+
+## 7. Lagringstid
+
+| Type data | Lagringstid |
+|---|---|
+| Samtykkevalg (`cookie-consent`) | Lagres i nettleseren din til du sletter den manuelt |
+| Skjemainnsendinger | Eksportfiske.no lagrer ingen kopi; videreformidles til export.fish |
+| Analyseinformasjon (Google Analytics) | I henhold til Google Analytics standard (14 måneder med mindre vi justerer ned) |
+
+## 8. Sikkerhetstiltak
+
+- All trafikk til og fra siden krypteres med HTTPS/TLS
+- Statisk hosting via GitHub Pages med standard sikkerhetstiltak fra GitHub
+- Ingen brukerdatabaser eller sensitive datalagringer på selve siden
+
+## 9. Dine rettigheter etter GDPR
+
+Som registrert har du følgende rettigheter:
+
+- **Innsyn (art. 15):** Du kan be om innsyn i hvilke opplysninger vi har om deg.
+- **Retting (art. 16):** Du kan be om at uriktige opplysninger rettes.
+- **Sletting (art. 17):** Du kan be om sletting av opplysninger der det ikke foreligger lovpålagt lagringsplikt.
+- **Dataportabilitet (art. 20):** Du kan be om å få utlevert dine data i maskinlesbart format.
+- **Innsigelse (art. 21):** Du kan protestere mot behandling basert på berettiget interesse.
+
+For å benytte dine rettigheter, kontakt oss på [kontakt@eksportfiske.no](mailto:kontakt@eksportfiske.no). Vi vil svare innen 30 dager.
+
+Du har også rett til å klage til **Datatilsynet** hvis du mener behandlingen er i strid med personvernregelverket: [datatilsynet.no](https://www.datatilsynet.no).
+
+## 10. Kontaktinformasjon for personvern
+
+For alle spørsmål om personvern og behandling av personopplysninger på eksportfiske.no:
+
+**E-post:** [kontakt@eksportfiske.no](mailto:kontakt@eksportfiske.no)
+
+**Organisasjon:** EIK IT
+**Organisasjonsnummer:** 993981532

--- a/src/content/legal/vilkar.md
+++ b/src/content/legal/vilkar.md
@@ -1,6 +1,8 @@
-# Vilkår for bruk av export.fish
+# Vilkår for abonnement på export.fish
 
-Velkommen til export.fish. Disse vilkårene regulerer bruken av våre tjenester for fangstrapportering fra turistfiskevirksomhet. Ved å registrere din bedrift og ta i bruk tjenesten aksepterer du disse vilkårene.
+Disse vilkårene regulerer abonnementsforholdet mellom Eksportfiske.no (EIK IT) og turistfiskebedrifter som registrerer seg via eksportfiske.no. Ved å registrere din bedrift og ta i bruk tjenesten aksepterer du disse vilkårene.
+
+**Relatert:** Selve rapporteringsverktøyet export.fish har egne sluttbrukervilkår som regulerer turistens og fiskerens bruk av PWA-en (fangstregistrering, eksportdokumenter osv.). Se [export.fish sine vilkår](https://export.fish/terms) og [personvernerklæring](https://export.fish/privacy) for de detaljene.
 
 ## 1. Tjenestebeskrivelse
 
@@ -31,30 +33,9 @@ Som turistfiskebedrift forplikter du deg til å:
 
 ## 4. Databehandling og personvern
 
-### 4.1 Dataansvar
-Eksportfiske.no er databehandler for registrerte fangstdata. Turistfiskebedriften er dataansvarlig for turistenes kontaktinformasjon.
+Eksportfiske.no behandler personopplysninger i forbindelse med abonnementet (bedriftsinformasjon og kontaktdata) og leveransen av tjenesten. Fullstendig informasjon om hvilke opplysninger som behandles, behandlingsgrunnlag, lagringstid, underleverandører og dine rettigheter etter GDPR finnes i [Personvernerklæringen](/personvern).
 
-### 4.2 Innsamlet informasjon
-Tjenesten samler inn:
-- Bedriftsinformasjon (organisasjonsnummer, navn, kontaktperson).
-- Turistinformasjon (e-postadresse for tilgangskontroll).
-- Fangstdata (art, antall, dato, lokasjon).
-
-### 4.3 Behandlingsgrunnlag
-Data behandles for å oppfylle lovpålagt rapporteringsplikt i henhold til Forskrift om rapportering av fangst fra turistfiskevirksomhet.
-
-### 4.4 Datadeling
-Fangstdata rapporteres automatisk til Fiskeridirektoratet i henhold til lovkrav. Data deles ikke med andre tredjeparter uten ditt samtykke.
-
-### 4.5 Bruk av signatur
-Den håndskrevne signaturen som samles inn under registrering brukes på utførselsdokumentasjon generert av tjenesten. Signaturen vil kun brukes til utstedelse av eksportdokumenter for turister. Annen bruk av signaturen er ikke tillatt.
-
-### 4.6 Brukerrettigheter
-I henhold til GDPR har turistene rett til:
-- Innsyn i egne registrerte data.
-- Retting av uriktige opplysninger.
-- Sletting av data der det ikke foreligger lovpålagt lagringsplikt.
-- Dataportabilitet.
+For personopplysninger som behandles av selve rapporteringsverktøyet (fangstdata, turistinformasjon, signaturer til utførselsdokumentasjon m.m.), se [export.fish sin personvernerklæring](https://export.fish/privacy).
 
 ## 5. Immaterielle rettigheter
 

--- a/src/pages/personvern.astro
+++ b/src/pages/personvern.astro
@@ -33,18 +33,15 @@ const { Content } = await render(personvernEntry);
           <nav class="bg-white rounded-xl shadow-sm border border-gray-200 p-5 md:p-6" aria-label="Innholdsfortegnelse">
             <h2 class="text-lg font-bold text-gray-900 mb-4 pb-3 border-b border-gray-200">Innhold</h2>
             <ol class="space-y-2.5 text-sm">
-              <li><a href="#1-behandlingsansvarlig-og-databehandler" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">1. Behandlingsansvar</a></li>
-              <li><a href="#2-behandlingsgrunnlag" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">2. Behandlingsgrunnlag</a></li>
-              <li><a href="#3-hvilke-opplysninger-behandles" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">3. Opplysninger vi behandler</a></li>
-              <li><a href="#4-formål-med-behandlingen" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">4. Formål</a></li>
-              <li><a href="#5-lagringstid" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">5. Lagringstid</a></li>
-              <li><a href="#6-deling-av-data" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">6. Deling av data</a></li>
-              <li><a href="#7-underleverandører-databehandlere" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">7. Underleverandører</a></li>
-              <li><a href="#8-databehandleravtale" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">8. Databehandleravtale</a></li>
-              <li><a href="#9-sikkerhetstiltak" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">9. Sikkerhetstiltak</a></li>
-              <li><a href="#10-dine-rettigheter-etter-gdpr" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">10. Dine rettigheter</a></li>
-              <li><a href="#11-informasjonskapsler" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">11. Informasjonskapsler</a></li>
-              <li><a href="#12-kontaktinformasjon-for-personvern" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">12. Kontakt</a></li>
+              <li><a href="#1-behandlingsansvarlig" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">1. Behandlingsansvarlig</a></li>
+              <li><a href="#2-hvilke-opplysninger-samles-inn" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">2. Opplysninger vi samler inn</a></li>
+              <li><a href="#3-behandlingsgrunnlag" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">3. Behandlingsgrunnlag</a></li>
+              <li><a href="#4-informasjonskapsler-og-sporing" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">4. Informasjonskapsler</a></li>
+              <li><a href="#5-underleverandører" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">5. Underleverandører</a></li>
+              <li><a href="#6-lagringstid" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">6. Lagringstid</a></li>
+              <li><a href="#7-sikkerhetstiltak" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">7. Sikkerhetstiltak</a></li>
+              <li><a href="#8-dine-rettigheter-etter-gdpr" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">8. Dine rettigheter</a></li>
+              <li><a href="#9-kontaktinformasjon-for-personvern" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">9. Kontakt</a></li>
             </ol>
           </nav>
         </aside>

--- a/src/pages/personvern.astro
+++ b/src/pages/personvern.astro
@@ -1,0 +1,190 @@
+---
+import Layout from '../layouts/Layout.astro';
+import { getEntry, render } from 'astro:content';
+
+const personvernEntry = await getEntry('legal', 'personvern');
+const { Content } = await render(personvernEntry);
+---
+
+<Layout
+  title="Personvernerklæring — export.fish"
+  description="Personvernerklæring for export.fish. Les om hvilke opplysninger vi behandler, behandlingsgrunnlag, dine rettigheter og sikkerhetstiltak."
+>
+  <!-- Hero Section -->
+  <section class="pt-44 md:pt-52 pb-12 md:pb-16 bg-gradient-to-br from-primary-light via-blue-50 to-white">
+    <div class="container mx-auto px-4 max-w-5xl">
+      <div class="text-center mb-8">
+        <h1 class="text-3xl md:text-4xl lg:text-5xl font-bold text-gray-900 mb-3">
+          Personvernerklæring
+        </h1>
+        <p class="text-base md:text-lg text-gray-600">
+          Sist oppdatert: {new Date().toLocaleDateString('no-NO', { year: 'numeric', month: 'long', day: 'numeric' })}
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Content Section -->
+  <section class="py-8 md:py-12 bg-gray-50">
+    <div class="container mx-auto px-4 max-w-5xl">
+      <div class="grid lg:grid-cols-[280px_1fr] gap-8 lg:gap-12">
+        <!-- Sticky Table of Contents -->
+        <aside class="lg:sticky lg:top-28 lg:self-start">
+          <nav class="bg-white rounded-xl shadow-sm border border-gray-200 p-5 md:p-6" aria-label="Innholdsfortegnelse">
+            <h2 class="text-lg font-bold text-gray-900 mb-4 pb-3 border-b border-gray-200">Innhold</h2>
+            <ol class="space-y-2.5 text-sm">
+              <li><a href="#1-behandlingsansvarlig-og-databehandler" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">1. Behandlingsansvar</a></li>
+              <li><a href="#2-behandlingsgrunnlag" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">2. Behandlingsgrunnlag</a></li>
+              <li><a href="#3-hvilke-opplysninger-behandles" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">3. Opplysninger vi behandler</a></li>
+              <li><a href="#4-formål-med-behandlingen" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">4. Formål</a></li>
+              <li><a href="#5-lagringstid" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">5. Lagringstid</a></li>
+              <li><a href="#6-deling-av-data" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">6. Deling av data</a></li>
+              <li><a href="#7-underleverandører-databehandlere" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">7. Underleverandører</a></li>
+              <li><a href="#8-databehandleravtale" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">8. Databehandleravtale</a></li>
+              <li><a href="#9-sikkerhetstiltak" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">9. Sikkerhetstiltak</a></li>
+              <li><a href="#10-dine-rettigheter-etter-gdpr" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">10. Dine rettigheter</a></li>
+              <li><a href="#11-informasjonskapsler" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">11. Informasjonskapsler</a></li>
+              <li><a href="#12-kontaktinformasjon-for-personvern" class="text-gray-700 hover:text-primary transition-colors font-medium hover:underline block">12. Kontakt</a></li>
+            </ol>
+          </nav>
+        </aside>
+
+        <!-- Main Content -->
+        <div>
+          <article class="legal-content bg-white rounded-xl shadow-sm border border-gray-200 p-6 md:p-10 lg:p-12">
+            <Content />
+          </article>
+
+          <div class="mt-8 text-center">
+            <a
+              href="/vilkar"
+              class="inline-flex items-center gap-2 text-primary hover:text-primary-hover font-semibold transition-colors"
+            >
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+              </svg>
+              Les også vilkår for bruk
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</Layout>
+
+<style>
+  .legal-content {
+    color: #374151;
+    font-size: 1rem;
+    line-height: 1.75;
+  }
+
+  .legal-content > :global(h1:first-child) {
+    display: none;
+  }
+
+  .legal-content :global(h2) {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #111827;
+    margin-top: 3rem;
+    margin-bottom: 1.25rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 2px solid #e5e7eb;
+    scroll-margin-top: 120px;
+  }
+
+  .legal-content :global(h2:first-of-type) {
+    margin-top: 0;
+  }
+
+  .legal-content :global(h3) {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #1f2937;
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+    scroll-margin-top: 120px;
+  }
+
+  .legal-content :global(p) {
+    margin-bottom: 1.25rem;
+    line-height: 1.8;
+    color: #4b5563;
+  }
+
+  .legal-content :global(p:last-child) {
+    margin-bottom: 0;
+  }
+
+  .legal-content :global(ul),
+  .legal-content :global(ol) {
+    margin-bottom: 1.5rem;
+    padding-left: 1.75rem;
+    color: #4b5563;
+  }
+
+  .legal-content :global(li) {
+    margin-bottom: 0.625rem;
+    line-height: 1.75;
+  }
+
+  .legal-content :global(li::marker) {
+    color: #2196f3;
+    font-weight: 600;
+  }
+
+  .legal-content :global(strong) {
+    font-weight: 600;
+    color: #111827;
+  }
+
+  .legal-content :global(a) {
+    color: #2196f3;
+    text-decoration: underline;
+    text-decoration-color: #99d3ef;
+    text-underline-offset: 3px;
+    transition: all 0.2s ease;
+  }
+
+  .legal-content :global(a:hover) {
+    color: #1e88e5;
+    text-decoration-color: #2196f3;
+  }
+
+  .legal-content :global(hr) {
+    margin: 2.5rem 0;
+    border: 0;
+    border-top: 1px solid #e5e7eb;
+  }
+
+  .legal-content :global(table) {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1.5rem;
+    font-size: 0.9rem;
+  }
+
+  .legal-content :global(th) {
+    background: #f3f4f6;
+    font-weight: 600;
+    text-align: left;
+    padding: 0.625rem 0.875rem;
+    border: 1px solid #e5e7eb;
+    color: #111827;
+  }
+
+  .legal-content :global(td) {
+    padding: 0.625rem 0.875rem;
+    border: 1px solid #e5e7eb;
+    color: #4b5563;
+  }
+
+  .legal-content :global(tr:nth-child(even) td) {
+    background: #f9fafb;
+  }
+
+  .legal-content :global([id]) {
+    scroll-margin-top: 120px;
+  }
+</style>


### PR DESCRIPTION
## Bakgrunn (audit-finding)

Vilkår nevner databehandler-rollen, men siden manglet en tydelig, selvstendig personvernerklæring. Dette er et krav for GDPR-samsvar og forventet av Fiskeridirektoratet som fagsystem-godkjent aktør.

## Endringer

- `src/content/legal/personvern.md`: ny personvernerklæring med GDPR art. 6 behandlingsgrunnlag, opplysningskategorier, lagringstider, underleverandørliste (med plassholde for konkrete navn), sikkerhetstiltak, rettigheter, og kontaktpunkt
- `src/pages/personvern.astro`: ny side som renderer personvern.md, identisk layout som vilkar.astro, med innholdsfortegnelse og tabellstiler
- `src/components/Footer.astro`: lenker til Personvernerklæring og Vilkår for bruk lagt til i Kontakt-kolonnen

## Oppfølging (utenfor denne PRen)

- Underleverandørtabellen (punkt 7) har to plassholde-rader for hosting- og e-postleverandør. Disse må fylles inn av Kim Eik med korrekte leverandørnavn og EØS-status
- Vurder om databehandleravtale skal ligge som separat side eller vedlegg til personvernerklæringen

## Test plan

- [ ] Kontroller `/personvern` at siden rendres korrekt med innholdsfortegnelse
- [ ] Kontroller tabellstiler for lagringstid og underleverandørliste
- [ ] Sjekk footer på alle sider at lenker til Personvernerklæring og Vilkår for bruk vises
- [ ] Sjekk at `/personvern` er inkludert i sitemap
- [ ] `npm run build` passerer (verifisert, 30 sider bygget)