### PR TITLE
Tydeligere hero-CTA for regelverksstressede utleiere

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -76,7 +76,7 @@ import sei from '../assets/sei.png';
           class="relative overflow-hidden bg-white text-blue-900 hover:bg-blue-50 font-semibold text-base sm:text-lg px-6 sm:px-8 py-3 sm:py-4 rounded-lg transition-all transform hover:scale-105 shadow-xl text-center"
           href="/registrer"
         >
-          <span class="relative z-10">Bestill nå</span>
+          <span class="relative z-10">Kom i gang med godkjent rapportering</span>
         </a>
         <a
           class="bg-transparent hover:bg-white/10 text-white font-semibold text-base sm:text-lg px-6 sm:px-8 py-3 sm:py-4 rounded-lg border-2 border-white/30 transition-colors text-center"


### PR DESCRIPTION
## Bakgrunn (audit-finding)

Hero-CTA \"Bestill nå\" er generisk og treffer ikke den faktiske målgruppen. Hytteutleiere som er bekymret for regelverket reagerer på trygghet og klarhet, ikke kjøpsoppfordringer.

## Endringer

- `src/pages/index.astro`: primær CTA i hero endret fra \"Bestill nå\" til \"Kom i gang med godkjent rapportering\"

Valget \"Kom i gang med godkjent rapportering\" er foretrukket fordi det:
- Speiler tillitstegnet (godkjent fagsystem) direkte
- Er handlingsorientert og spesifikt
- Adresserer bekymringen (rapportering) fremfor kjøpet

## Test plan

- [ ] Kontroller at CTA-knapp vises korrekt i hero på forsiden
- [ ] Sjekk mobilvisning at lengre tekst passer i knappen
- [ ] Verifiser at href fremdeles peker til /registrer
- [ ] `npm run build` passerer (verifisert lokalt)