### PR TITLE
Trigger deploy.yml manuelt etter auto-merge

### DIFF
--- a/.github/workflows/scheduled-publish.yml
+++ b/.github/workflows/scheduled-publish.yml
@@ -59,3 +59,11 @@ jobs:
           echo "Merger PR #${PR_NUMBER}..."
           gh pr merge "${PR_NUMBER}" --squash --delete-branch
           echo "PR #${PR_NUMBER} merget."
+
+          # GitHub stopper workflows som trigges av GITHUB_TOKEN fra å starte
+          # nye workflows (recursive run protection). Merge-commit'en over vil
+          # derfor IKKE trigge deploy.yml automatisk. Vi må sparke den i gang
+          # manuelt via workflow_dispatch.
+          echo "Sparker i gang deploy.yml mot master..."
+          gh workflow run deploy.yml --ref master
+          echo "deploy.yml trigget."


### PR DESCRIPTION
## Problem

scheduled-publish.yml merger PR-en for dagens dato via GITHUB_TOKEN, men GitHub har en innebygd recursive run protection som hindrer at workflows trigget av GITHUB_TOKEN starter nye workflows. Resultat: merge-commit'en på master trigger ikke deploy.yml, og artikkelen blir merget men aldri deployet.

## Løsning

Legger til et manuelt workflow_dispatch-kall mot deploy.yml rett etter merge, i samme jobb. workflow_dispatch er ikke underlagt samme beskyttelse.

## Verifisert

- Manuell test 2026-05-15: PR [#222] ble merget av workflowen kl. 07:51:29 uten at deploy.yml startet. Manuell trigger av deploy.yml fungerte umiddelbart.

## Alternativer vurdert

- Bytte til Personal Access Token: renere arkitektur, men krever vedlikehold av PAT-secret. Manuell workflow_dispatch er enklere og holder seg innenfor default-tokenets rettighetsmodell.