### PR TITLE
SEO: forsidestitel, meta-beskrivelse og Kort svar-blokk

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,8 +18,8 @@ import sei from '../assets/sei.png';
 ---
 
 <Layout
-  title="Lovpålagt fangstrapportering for hytteutleiere"
-  description="Utleie av hytte med båt til turistfiskere? Sjekk reglene for fangstrapportering. Tyskere og andre turister kan eksportere fisk fra Norge med riktig dokumentasjon. Unngå bøter ."
+  title="Godkjent fangstrapportering for turistfiskebedrifter | Eksportfiske.no"
+  description="Leier du ut hytte med båt? Du har lovpålagt plikt til daglig fangstrapportering til Fiskeridirektoratet. export.fish er et godkjent rapporteringssystem. Prøv gratis i 30 dager."
 >
 
   <!-- Hero Section -->
@@ -112,6 +112,39 @@ import sei from '../assets/sei.png';
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
         </svg>
       </a>
+    </div>
+  </section>
+
+  <!-- Kort svar-blokk -->
+  <section id="kort-svar" class="py-12 bg-white border-y border-gray-100">
+    <div class="max-w-3xl mx-auto px-4">
+      <div class="bg-blue-50 border border-blue-200 rounded-2xl p-6 md:p-8">
+        <p class="text-xs font-semibold uppercase tracking-wider text-blue-600 mb-3">Kort svar</p>
+        <h2 class="text-xl md:text-2xl font-bold text-gray-900 mb-4">
+          Hva er lovpålagt fangstrapportering for turistfiskebedrifter?
+        </h2>
+        <p class="text-gray-700 leading-relaxed mb-4">
+          Alle virksomheter som tar betalt for utleie av båt til turistfiskere har plikt til å rapportere fangst daglig til Fiskeridirektoratet. Plikten gjelder uavhengig av om du markedsfører deg som turistfiskebedrift, og fra august 2025 er kravet daglig rapportering. Export.fish er et godkjent elektronisk rapporteringssystem som oppfyller alle krav i forskriften automatisk.
+        </p>
+        <ul class="space-y-2 text-sm text-gray-700 mb-5">
+          <li class="flex items-start gap-2">
+            <svg class="w-4 h-4 text-blue-500 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>
+            <span>Plikten inntreffer når du tar betalt, er MVA-registrert og har inntekt over 50 000 kr/år</span>
+          </li>
+          <li class="flex items-start gap-2">
+            <svg class="w-4 h-4 text-blue-500 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>
+            <span>Boten for manglende rapportering kan være opptil 50 000 kroner</span>
+          </li>
+          <li class="flex items-start gap-2">
+            <svg class="w-4 h-4 text-blue-500 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>
+            <span>Godkjent rapportering er også forutsetning for at gjestene kan skaffe eksportdokument</span>
+          </li>
+        </ul>
+        <a href="/registrer/" class="inline-flex items-center gap-2 text-blue-700 hover:text-blue-800 font-semibold text-sm transition-colors">
+          Kom i gang med export.fish
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+        </a>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Endringer

### Tittel og meta
- Ny `<title>`: "Godkjent fangstrapportering for turistfiskebedrifter | Eksportfiske.no" (matcher primært søk)
- Ny meta-beskrivelse: Fjerner trailing space-feil, legger til "godkjent rapporteringssystem", "Prøv gratis 30 dager"

### Kort svar-blokk
Ny seksjon (`id="kort-svar"`) mellom Om oss-teaseren og fordels-seksjonene. Besvarer direkte: "Hva er lovpålagt fangstrapportering for turistfiskebedrifter?" med:
- Kortfattet svar i ett avsnitt
- Tre konkrete punkter (registreringsterskel, bot-risiko, eksportdokument-kobling)
- CTA til registrering

Blokken er optimalisert for Featured Snippet og AI-svar (AEO/GEO). Ingen em-strek i teksten.

## Testing

Bygget lokalt, 29 sider uten feil.

Epic: https://github.com/eik-it/export.fish-site/issues/293