### PR TITLE
SEO: ProofBlock-komponent og Fiskeridirektoratet-lenke i footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -13,7 +13,20 @@ import logo from '../assets/logo.png';
           <span class="text-xl font-bold text-white">Eksportfiske</span>
         </div>
         <p class="text-sm text-gray-400">
-          Enkel fangstrapportering for turistfiskebedrifter i hele Norge. Godkjent av Fiskeridirektoratet.
+          Enkel fangstrapportering for turistfiskebedrifter i hele Norge.
+        </p>
+        <p class="text-sm mt-2">
+          <a
+            href="https://www.fiskeridir.no/turistfiske/rapportering-for-turistfiskebedrifter"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-1.5 text-green-400 hover:text-green-300 transition-colors"
+          >
+            <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+            </svg>
+            Godkjent av Fiskeridirektoratet
+          </a>
         </p>
       </div>
 

--- a/src/components/ProofBlock.astro
+++ b/src/components/ProofBlock.astro
@@ -1,0 +1,60 @@
+---
+/**
+ * ProofBlock — Fiskeridirektoratet-godkjenning proof signal.
+ *
+ * Gjenbrukbar komponent som viser at export.fish er et godkjent
+ * rapporteringssystem fra Fiskeridirektoratet. Kan brukes på forsiden,
+ * landingssider og blogginnlegg for å styrke E-E-A-T og bygge tillit.
+ *
+ * Props:
+ *   variant: "banner" (standard, for inlining i innhold) | "badge" (liten, for sidebarer)
+ *   showLink: om lenke til Fiskeridirektoratets side skal vises (standard: true)
+ */
+interface Props {
+  variant?: 'banner' | 'badge';
+  showLink?: boolean;
+}
+
+const { variant = 'banner', showLink = true } = Astro.props;
+---
+
+{variant === 'banner' && (
+  <div class="flex flex-col sm:flex-row items-start sm:items-center gap-3 bg-green-50 border border-green-200 rounded-xl px-5 py-4">
+    <div class="flex-shrink-0 w-10 h-10 bg-green-100 rounded-full flex items-center justify-center">
+      <svg class="w-5 h-5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+      </svg>
+    </div>
+    <div class="flex-1 min-w-0">
+      <p class="text-sm font-semibold text-green-800">
+        Godkjent rapporteringssystem fra Fiskeridirektoratet
+      </p>
+      <p class="text-xs text-green-700 mt-0.5">
+        Oppfyller kravene i Forskrift om rapportering av fangst fra turistfiskevirksomhet (FOR-2017-07-05-1141).
+        {showLink && (
+          <>
+            {' '}
+            <a
+              href="https://www.fiskeridir.no/turistfiske/rapportering-for-turistfiskebedrifter"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="underline hover:text-green-900 transition-colors"
+            >
+              Se godkjente systemer hos Fiskeridirektoratet
+            </a>
+            .
+          </>
+        )}
+      </p>
+    </div>
+  </div>
+)}
+
+{variant === 'badge' && (
+  <div class="inline-flex items-center gap-2 bg-green-50 border border-green-200 rounded-full px-3 py-1.5">
+    <svg class="w-4 h-4 text-green-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+    </svg>
+    <span class="text-xs font-semibold text-green-800">Godkjent av Fiskeridirektoratet</span>
+  </div>
+)}


### PR DESCRIPTION
## Endringer

### Ny komponent: ProofBlock.astro
Gjenbrukbar komponent for å vise Fiskeridirektoratet-godkjenning.

- `variant="banner"`: Full boks for inline-bruk i innhold (forsiden, landingssider)
- `variant="badge"`: Liten pill-badge for sidefelter og header

Begge inkluderer lenke til Fiskeridirektoratets liste over godkjente systemer (kan slås av med `showLink={false}`).

### Footer.astro
Bytter ut statisk tekst "Godkjent av Fiskeridirektoratet" med en klikkbar lenke til Fiskeridirektoratets side. Gir søkemotorer og AI-agenter et verifiserbart autoritetssignal via en ekstern lenke.

## Merknader

ProofBlock brukes ikke på forsiden i denne PRen (forsiden har allerede en trust badge i hero-seksjonen). Komponenten er klar for bruk i fase 2-landingssidene.

Avhenger logisk av PR 294 (schema-fiks) da begge er del av samme SEO-runde, men har ingen teknisk filkonflikt.

Epic: https://github.com/eik-it/export.fish-site/issues/293