### PR TITLE
feat: landingsside /turistfiske-regler/ (SEO hub)

### DIFF
--- a/src/pages/turistfiske-regler/index.astro
+++ b/src/pages/turistfiske-regler/index.astro
@@ -1,0 +1,213 @@
+---
+import Layout from '../../layouts/Layout.astro';
+---
+
+<Layout
+  title="Turistfiske regler: komplett oversikt for norske turistfiskebedrifter"
+  description="Alt om regelverket for turistfiske i Norge: registreringsplikt, daglig fangstrapportering, utførselskvote, eksportdokumentasjon og bøter. Oppdatert for 2025-kravene."
+>
+  <Fragment slot="head">
+    <script type="application/ld+json">{JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "Hvem har rapporteringsplikt for turistfiske?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Alle virksomheter som tar betalt for utleie av båt til turistfiskere, er MVA-registrerte og har bruttoinntekt over 50 000 kr per år fra slik utleie. Plikten gjelder uavhengig av om virksomheten markedsfører seg som turistfiskebedrift."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Hva er utførselskvoten for fisk fra Norge?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Utenlandske turister kan ta med inntil 18 kg fisk pluss én hel fisk per person per dag ut av Norge. Utførselen krever eksportdokument utstedt av turistfiskevirksomheten."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Hva er boten for manglende fangstrapportering?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Fiskeridirektoratet kan ilegge overtredelsesgebyr på inntil 50 000 kroner for turistfiskebedrifter som ikke oppfyller rapporteringsplikten."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Hva er nytt i 2025-forskriften?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Fra 1. august 2025 kreves daglig fangstrapportering til Fiskeridirektoratet. Tidligere var det tilstrekkelig med periodisk rapportering. I tillegg er trofisk fisk (stor fisk brukt som trekkplaster) forbudt å ta med ut av Norge."
+          }
+        }
+      ]
+    })}</script>
+    <script type="application/ld+json">{JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Hjem", "item": "https://eksportfiske.no/" },
+        { "@type": "ListItem", "position": 2, "name": "Turistfiske regler", "item": "https://eksportfiske.no/turistfiske-regler/" }
+      ]
+    })}</script>
+  </Fragment>
+
+  <article class="pt-44 pb-16 bg-white">
+    <div class="max-w-2xl mx-auto px-4">
+
+      <nav class="text-sm text-gray-500 mb-6" aria-label="Brødsmulesti">
+        <ol class="flex items-center gap-2">
+          <li><a href="/" class="hover:text-primary transition">Hjem</a></li>
+          <li aria-hidden="true">/</li>
+          <li class="text-gray-900 font-medium">Turistfiske regler</li>
+        </ol>
+      </nav>
+
+      <header class="mb-8">
+        <h1 class="text-3xl md:text-4xl font-bold text-gray-900 leading-tight mb-4">
+          Turistfiske regler: komplett oversikt for norske turistfiskebedrifter
+        </h1>
+        <p class="text-xl text-gray-600 leading-relaxed">
+          Alt om registreringsplikt, daglig fangstrapportering, utførselskvote og eksportdokumentasjon. Oppdatert for 2025-kravene.
+        </p>
+      </header>
+
+      <div class="flex flex-col sm:flex-row items-start sm:items-center gap-3 bg-green-50 border border-green-200 rounded-xl px-5 py-4">
+        <div class="flex-shrink-0 w-10 h-10 bg-green-100 rounded-full flex items-center justify-center">
+          <svg class="w-5 h-5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+          </svg>
+        </div>
+        <div>
+          <p class="text-sm font-semibold text-green-800">Godkjent rapporteringssystem fra Fiskeridirektoratet</p>
+          <p class="text-xs text-green-700 mt-0.5">Oppfyller kravene i Forskrift om rapportering av fangst fra turistfiskevirksomhet (FOR-2017-07-05-1141). <a href="https://www.fiskeridir.no/turistfiske/rapportering-for-turistfiskebedrifter" target="_blank" rel="noopener noreferrer" class="underline hover:text-green-900 transition-colors">Se godkjente systemer hos Fiskeridirektoratet</a>.</p>
+        </div>
+      </div>
+
+      <div class="article-body text-gray-800 leading-relaxed mt-8">
+
+        <div class="bg-blue-50 border border-blue-200 rounded-xl p-5 mb-8">
+          <p class="text-xs font-semibold uppercase tracking-wider text-blue-600 mb-2">Kort svar</p>
+          <p class="text-gray-800">
+            Norske turistfiskebedrifter som tar betalt for utleie av båt til utenlandske gjester har lovpålagt plikt til å rapportere fangst daglig til Fiskeridirektoratet, og til å utstede godkjent eksportdokumentasjon for gjester som skal ta fisk ut av Norge. Manglende rapportering kan medføre bot på opptil 50 000 kroner.
+          </p>
+        </div>
+
+        <h2>Hva er en turistfiskebedrift?</h2>
+        <p>
+          En turistfiskebedrift er etter norsk lov enhver virksomhet som mot betaling legger til rette for at turister kan fiske i norske farvann, og som stiller båt til disposisjon. Det er ikke nødvendig å markedsføre seg eksplisitt som turistfiskebedrift — om kriteriene er oppfylt, gjelder reglene.
+        </p>
+        <p>
+          Registreringsplikten hos Fiskeridirektoratet inntreffer når alle tre vilkår er oppfylt: du tar betalt for utleie, er MVA-registrert, og forventer bruttoinntekt over 50 000 kr/år fra slik virksomhet. Les mer: <a href="/blogg/ma-du-registrere-turistfiskebedrift/">Må du registrere turistfiskebedrift?</a>
+        </p>
+
+        <h2>Daglig fangstrapportering fra august 2025</h2>
+        <p>
+          Fra 1. august 2025 gjelder krav om daglig rapportering av fangst til Fiskeridirektoratet. Tidligere var periodisk rapportering tilstrekkelig. Kravet betyr at all fangst skal registreres og sendes til Fiskeridirektoratet senest innen dagens slutt.
+        </p>
+        <p>
+          Et godkjent elektronisk rapporteringssystem som export.fish håndterer dette automatisk: turistene registrerer fangst daglig i appen, og systemet rapporterer til Fiskeridirektoratet på vegne av bedriften. Les mer: <a href="/fangstrapportering-turistfiske/">Daglig fangstrapportering for turistfiske</a>
+        </p>
+
+        <h2>Utførselskvote og eksportdokumentasjon</h2>
+        <p>
+          Utenlandske turister har rett til å ta med seg fisk ut av Norge, men bare innenfor utførselskvoten og med korrekt dokumentasjon:
+        </p>
+        <ul>
+          <li>Kvote: 18 kg fisk + én hel fisk per person per dag</li>
+          <li>Dokumentasjon: eksportdokument utstedt av turistfiskevirksomheten</li>
+          <li>Krav: dokumentet kan ikke utstedes før fangsten er rapportert</li>
+        </ul>
+        <p>
+          Boten for ulovlig utførsel er 8 000 kroner pluss 200 kroner per kilo i overskudd. Les mer: <a href="/utforselsdokumentasjon-fisk/">Utførselsdokumentasjon for fisk</a>
+        </p>
+
+        <h2>Bøter og sanksjoner</h2>
+        <p>
+          Fiskeridirektoratet kan ilegge overtredelsesgebyr for brudd på rapporteringsplikten. Gebyret kan være opp til 50 000 kroner for turistfiskebedrifter. Les mer: <a href="/blogg/bot-for-turistfiske-rapportering/">Bot for turistfiske-rapportering</a>
+        </p>
+
+        <h2>Regelverk for hytteutleiere</h2>
+        <p>
+          Fritidsboligeiere som leier ut hytte med båt er i mange tilfeller underlagt de samme reglene som ordinære turistfiskebedrifter. Nøkkelen er om du tar betalt for utleien og stiller båt til disposisjon. Les mer: <a href="/hytteutleie-med-bat-regler/">Regler for hytteutleie med båt</a>
+        </p>
+
+        <h2>Aldersgrenser</h2>
+        <p>
+          Barn under 12 år er unntatt fra kravet om fangstrapportering. Fangsten deres trenger ikke registreres, og de teller ikke i utførselskvoten. Les mer: <a href="/blogg/aldersgrense-turistfiske-12-ar/">Aldersgrense i turistfiske</a>
+        </p>
+
+        <h2>Minstemål og fredningstider</h2>
+        <p>
+          I tillegg til rapporteringsplikten gjelder ordinære fiskerireguleringer: minstemål for ulike arter og fredningstider. Les mer: <a href="/blogg/minstemal-fredningstider-tabell/">Minstemål og fredningstider</a>
+        </p>
+
+        <h2>Godkjent rapporteringssystem</h2>
+        <p>
+          Fiskeridirektoratet krever bruk av et godkjent elektronisk rapporteringssystem. Export.fish er et slikt system og håndterer hele flyten: daglig fangstregistrering, automatisk rapportering til Fiskeridirektoratet, og utstedelse av eksportdokumentasjon. Les mer: <a href="/godkjent-rapporteringssystem-turistfiske/">Godkjent rapporteringssystem for turistfiske</a>
+        </p>
+
+      </div>
+    </div>
+  </article>
+
+  <section class="py-16 bg-gradient-to-br from-blue-50 to-slate-50">
+    <div class="max-w-2xl mx-auto px-4 text-center">
+      <h2 class="text-2xl md:text-3xl font-bold text-gray-900 mb-4">
+        Oppfyll rapporteringsplikten med export.fish
+      </h2>
+      <p class="text-lg text-gray-600 mb-8">
+        Godkjent system for daglig fangstrapportering og eksportdokumentasjon. Prøv gratis i 30 dager.
+      </p>
+      <div class="flex flex-col sm:flex-row gap-4 justify-center">
+        <a
+          href="/registrer/"
+          class="bg-primary hover:bg-primary-hover text-white font-semibold px-8 py-4 rounded-lg transition-colors text-center shadow-md hover:shadow-lg"
+        >
+          Kom i gang gratis
+        </a>
+        <a
+          href="/registrering"
+          class="border-2 border-primary text-primary hover:bg-primary hover:text-white font-semibold px-8 py-4 rounded-lg transition-colors text-center"
+        >
+          Les om registrering
+        </a>
+      </div>
+    </div>
+  </section>
+</Layout>
+
+<style>
+  .article-body :global(h2) {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #111827;
+    margin-top: 2.5rem;
+    margin-bottom: 1rem;
+    line-height: 1.3;
+  }
+  .article-body :global(p) {
+    margin-bottom: 1.25rem;
+    line-height: 1.75;
+  }
+  .article-body :global(ul) {
+    padding-left: 1.5rem;
+    margin-bottom: 1.25rem;
+    list-style-type: disc;
+  }
+  .article-body :global(li) {
+    margin-bottom: 0.5rem;
+    line-height: 1.75;
+  }
+  .article-body :global(a) {
+    color: #2196f3;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  .article-body :global(a:hover) {
+    color: #1e88e5;
+  }
+</style>


### PR DESCRIPTION
## Ny landingsside: /turistfiske-regler/

Overordnet hub-side for all turistfiske-regelverksinformasjon på eksportfiske.no.

### Innhold
- H1 og meta optimalisert for søket "turistfiske regler"
- Kort svar-blokk høyt på siden
- ProofBlock (Fiskeridirektoratet-godkjenning) med ekstern autoritetslenke
- Seksjonert innhold: hvem har plikt, daglig rapportering, utførselskvote, bøter, hytteutleiere, aldersgrenser
- Internlenker til alle 4 andre landingssider og relevante blogginnlegg
- FAQPage JSON-LD schema (4 spørsmål)
- BreadcrumbList JSON-LD schema

### Teknisk
- Ny side, ingen eksisterende URL berørt
- Builds til 30 sider (fra 29)

Epic: https://github.com/eik-it/export.fish-site/issues/293